### PR TITLE
postprocessors can have context

### DIFF
--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -156,9 +156,9 @@ State.prototype.process = function(location, table, rules, addedRules) {
 
 
 
-function Parser(rules, start) {
+function Parser(rules, start, context) {
     var table = this.table = [];
-    this.rules = rules.map(function (r) { return (new Rule(r.name, r.symbols, r.postprocess)); });
+    this.rules = rules.map(function (r) { return (new Rule(r.name, r.symbols, r.postprocess ? r.postprocess.bind(context) : r.postprocess)); });
     this.start = start = start || this.rules[0].name;
     // Setup a table
     var addedRules = [];

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "compiler"
   ],
   "scripts": {
-    "test": "npm install && sh build.sh"
+    "pretest": "npm install && sh build.sh",
+    "test": "sh test/unittests/build.sh && mocha test/unittests/**.js"
   },
   "author": "Hardmath123",
   "contributors": [
@@ -30,5 +31,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/hardmath123/nearley.git"
+  },
+  "devDependencies": {
+    "mocha": "^2.2.5"
   }
 }

--- a/test/unittests/build.sh
+++ b/test/unittests/build.sh
@@ -1,0 +1,1 @@
+bin/nearleyc.js test/unittests/context-grammar.ne -o test/unittests/context-grammar.js;

--- a/test/unittests/context-grammar.js
+++ b/test/unittests/context-grammar.js
@@ -1,0 +1,32 @@
+// Generated automatically by nearley
+// http://github.com/Hardmath123/nearley
+(function () {
+function id(x) {return x[0]; }
+var grammar = {
+    ParserRules: [
+    {"name": "program", "symbols": ["_", "uc", "_"], "postprocess":  function (d) { return this.id(d[1]) } },
+    {"name": "program", "symbols": ["_", "lc", "_"], "postprocess":  function (d) { return this.id(d[1]) } },
+    {"name": " string$1", "symbols": [{"literal":"t"}, {"literal":"o"}, {"literal":"u"}, {"literal":"p"}, {"literal":"p"}, {"literal":"e"}, {"literal":"r"}], "postprocess": function joiner(d) {
+        return d.join('');
+    }},
+    {"name": "uc", "symbols": [" string$1", "_", "string"], "postprocess":  function (d) { return this.toUpper(d[2]) } },
+    {"name": " string$2", "symbols": [{"literal":"t"}, {"literal":"o"}, {"literal":"l"}, {"literal":"o"}, {"literal":"w"}, {"literal":"e"}, {"literal":"r"}], "postprocess": function joiner(d) {
+        return d.join('');
+    }},
+    {"name": "lc", "symbols": [" string$2", "_", "string"], "postprocess":  function (d) { return this.toLower(d[2]) } },
+    {"name": "string", "symbols": [{"literal":"'"}, " ebnf$3", {"literal":"'"}], "postprocess":  function (d) { return this.string(d[1]) } },
+    {"name": "_", "symbols": [], "postprocess":  function(d) { return this.null(); } },
+    {"name": "_", "symbols": [/[\s]/, "_"], "postprocess":  function(d) {return this.null(); } },
+    {"name": " ebnf$3", "symbols": []},
+    {"name": " ebnf$3", "symbols": [/[a-zA-Z ]/, " ebnf$3"], "postprocess": function (d) {
+                    return [d[0]].concat(d[1]);
+                }}
+]
+  , ParserStart: "program"
+}
+if (typeof module !== 'undefined'&& typeof module.exports !== 'undefined') {
+   module.exports = grammar;
+} else {
+   window.grammar = grammar;
+}
+})();

--- a/test/unittests/context-grammar.ne
+++ b/test/unittests/context-grammar.ne
@@ -1,0 +1,11 @@
+program -> _ uc _ {% function (d) { return this.id(d[1]) } %}
+        | _ lc _ {% function (d) { return this.id(d[1]) } %}
+
+uc -> "toupper" _ string {% function (d) { return this.toUpper(d[2]) } %}
+
+lc -> "tolower" _ string {% function (d) { return this.toLower(d[2]) } %}
+
+string -> "'" [a-zA-Z ]:* "'" {% function (d) { return this.string(d[1]) } %}
+
+_ -> null       {% function(d) { return this.null(); } %}
+	| [\s] _    {% function(d) {return this.null(); } %}

--- a/test/unittests/context-grammar.test.js
+++ b/test/unittests/context-grammar.test.js
@@ -1,0 +1,56 @@
+var nearley = require("../../");
+var grammar = require("./context-grammar.js")
+var assert = require('assert')
+
+
+describe('Parser([rules], [start], [context])', function () {
+  it('will invoke each rule (e.g postprocessor) with context as this', function () {
+    assertParse('toupper \'HeLLo wORLd\'', 'HELLO WORLD')
+    assertParse('tolower \'HeLLo wORLd\'', 'hello world')
+  })
+
+  function assertParse(text, expected) {
+    var p = new nearley.Parser(grammar.ParserRules, grammar.ParserStart, createContext())
+    p.feed(text)
+
+    assert.equal(p.results, expected, [
+      'Expected parsing of "', text,
+      '" to be "', expected,
+      '" but got "', p.results, '"'
+    ].join(''))
+  }
+
+  function createContext() {
+    return {
+      null: function (d) {
+        // console.log('null: %j', d)
+        return null
+      },
+      id: function (d) {
+        // console.log('id: %j', d)
+        return d
+      },
+      string: function (d) {
+        // console.log('string: %j', d)
+        return d.join('')
+      },
+      toUpper: function (d) {
+        // console.log('toUpper: %j', d)
+        return d.toUpperCase()
+      },
+      toLower: function (d) {
+        // console.log('toLower: %j', d)
+        return d.toLowerCase()
+      }
+    }
+  }
+})
+/*
+var p = new nearley.Parser(grammar.ParserRules, grammar.ParserStart, context)
+p.feed('toupper \'hello\'')
+console.log(p.results)
+
+
+p.feed('tolower \'WorlD\'')
+console.log(p.results)
+*/


### PR DESCRIPTION
I short, its possible to pass an optional context to Parser:

```
// js
var context = {foo: function (d) { ... }}
var p = new nearley.Parser(grammar.ParserRules, grammar.ParserStart, context)

...
// grammar
rule -> a b c {% function (d) { return this.foo(d) } %}
```

The motivation is that it in general makes it easier to construct more semantically bound ASTs and in particular allows complex logic to separated from the grammar specification.

I made some changes to the test structure:
- existing tests are now pre tests
- added unittests using mocha

Thanks for a great piece of work ;)
