### PR TITLE
Clearer edge cases

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -68,18 +68,26 @@ function Compile(structure, opts) {
             } else {
                 return undefined;
             }
-        } else if (token.subexpression) {
+        }
+
+        if (token.subexpression) {
             return buildSubExpressionToken(ruleName, token);
-        } else if (token.ebnf) {
+        }
+
+        if (token.ebnf) {
             return buildEBNFToken(ruleName, token);
-        } else if (typeof(token) === 'string') {
+        }
+
+        if (typeof(token) === 'string') {
             if (token !== 'null') return token;
             else return undefined;
-        } else if (token instanceof RegExp) {
-            return token;
-        } else {
-            throw new Error("Should never get here");
         }
+
+        if (token instanceof RegExp) {
+            return token;
+        }
+
+        throw new Error("Should never get here");
     }
 
     function buildStringToken(ruleName, token) {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -58,8 +58,8 @@ function Compile(structure, opts) {
 
     function buildToken(ruleName, token) {
         if (typeof(token) === 'string') {
-            if (token !== 'null') return token;
-            else return undefined;
+            if (token === 'null') return undefined;
+            return token;
         }
 
         if (token instanceof RegExp) {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -86,7 +86,7 @@ function Compile(structure, opts) {
             return buildEBNFToken(ruleName, token);
         }
 
-        throw new Error("Should never get here");
+        throw new Error("unrecognized token: " + JSON.stringify(token));
     }
 
     function buildStringToken(ruleName, token) {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -57,8 +57,10 @@ function Compile(structure, opts) {
     }
 
     function buildToken(ruleName, token) {
-        if (typeof(token) === 'string') {
-            if (token === 'null') return undefined;
+        if (typeof token === 'string') {
+            if (token === 'null') {
+                return null;
+            }
             return token;
         }
 
@@ -68,7 +70,7 @@ function Compile(structure, opts) {
 
         if (token.literal) {
             if (!token.literal.length) {
-                return undefined;
+                return null;
             }
             if (token.literal.length === 1) {
                 return token;

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -57,6 +57,15 @@ function Compile(structure, opts) {
     }
 
     function buildToken(ruleName, token) {
+        if (typeof(token) === 'string') {
+            if (token !== 'null') return token;
+            else return undefined;
+        }
+
+        if (token instanceof RegExp) {
+            return token;
+        }
+
         if (token.literal) {
             var str = token.literal;
             if (str.length > 1) {
@@ -76,15 +85,6 @@ function Compile(structure, opts) {
 
         if (token.ebnf) {
             return buildEBNFToken(ruleName, token);
-        }
-
-        if (typeof(token) === 'string') {
-            if (token !== 'null') return token;
-            else return undefined;
-        }
-
-        if (token instanceof RegExp) {
-            return token;
         }
 
         throw new Error("Should never get here");

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -65,6 +65,8 @@ function Compile(structure, opts) {
                 return {
                     literal: str
                 };
+            } else {
+                return undefined;
             }
         } else if (token.subexpression) {
             return buildSubExpressionToken(ruleName, token);
@@ -72,6 +74,7 @@ function Compile(structure, opts) {
             return buildEBNFToken(ruleName, token);
         } else if (typeof(token) === 'string') {
             if (token !== 'null') return token;
+            else return undefined;
         } else if (token instanceof RegExp) {
             return token;
         } else {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -45,7 +45,7 @@ function Compile(structure, opts) {
         var tokens = [];
         for (var i = 0; i < rule.tokens.length; i++) {
             var token = buildToken(ruleName, rule.tokens[i]);
-            if (token) {
+            if (token !== null) {
                 tokens.push(token);
             }
         }

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -67,16 +67,13 @@ function Compile(structure, opts) {
         }
 
         if (token.literal) {
-            var str = token.literal;
-            if (str.length > 1) {
-                return buildStringToken(ruleName, token);
-            } else if (str.length === 1) {
-                return {
-                    literal: str
-                };
-            } else {
+            if (!token.literal.length) {
                 return undefined;
             }
+            if (token.literal.length === 1) {
+                return token;
+            }
+            return buildStringToken(ruleName, token);
         }
 
         if (token.subexpression) {


### PR DESCRIPTION
Okay, a few things going on here:
- explicit null rather than undefined for skipping tokens in a rule
- which allows us to then pull apart the if/else ladder into a set of decoupled short-circuiting ifs
- which then allows us to easily re-order the checks, and expand them in future changes
- use said flexibility to do the inexpensive "atomic" checks first