### PR TITLE
fix npm test error on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
+    "coffee-script": "^1.10.0",
     "mocha": "^2.3.4"
   }
 }

--- a/test/launch.js
+++ b/test/launch.js
@@ -13,7 +13,7 @@ function sh(cmd) {
 }
 
 function nearleyc(args) {
-    return sh("bin/nearleyc.js " + args);
+    return sh("node bin/nearleyc.js " + args);
 }
 
 function load(compiledGrammar) {
@@ -65,7 +65,7 @@ describe("nearleyc", function() {
     });
 
     it('exponential whitespace bug', function() {
-        sh("bin/nearleyc.js test/indentation.ne");
+        sh("node bin/nearleyc.js test/indentation.ne");
     });
 
     it('nullable whitespace bug', function() {
@@ -76,7 +76,7 @@ describe("nearleyc", function() {
     });
 
     it('percent bug', function() {
-        sh("bin/nearleyc.js test/percent.ne");
+        sh("node bin/nearleyc.js test/percent.ne");
     });
 
 });


### PR DESCRIPTION
fix 'npm test' error ( test on windows 10 / node v5.8.0 & Linux 4.2.0-c9 / node v4.4.0 ) 

1.on windows you have to say 'node XX.js' instead of only 'XX.js'
2.to make test 'should build for CoffeeScript' pass, I add coffee script as dev dependency (I don't think I everybody install coffee script on their machine in 2016)