### PR TITLE
add build.js to make build process more portable

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,6 @@
+require('shelljs/global');
+
+echo('Building nearley...');
+exec('node bin/nearleyc.js lib/nearley-language-bootstrapped.ne > grammar.tmp');
+echo('Deleting temp file...');
+mv('grammar.tmp', './lib/nearley-language-bootstrapped.js');

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "coffee-script": "^1.10.0",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "shelljs": "^0.6.0"
   }
 }


### PR DESCRIPTION
The new build.js file behave exactly the same as build.sh except it does not run the test (test / launch.sh). 