### PR TITLE
add nearley-make as nearleyc alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ To compile a parser, use the `nearleyc` command:
 
 Run `nearleyc --help` for more options.
 
+There is also a version of `nearleyc` for node runtimes, [nearley-make](https://github.com/nanalan/nearley-make).
+
 To use a generated grammar in a node runtime, install `nearley` as a module:
 
     npm install nearley


### PR DESCRIPTION
I've created a package purely for compiling _and_ running a `grammar.ne` file called [nearley-make](https://github.com/nanalan/nearley-make).

It works inside JS runtimes only, rather than the shell. nearley-make takes a grammar source string as input and outputs an instance of `nearley.Parser`, so it's mostly for development purposes.