### PR TITLE
Performance optimization:

### DIFF
--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -71,11 +71,15 @@ State.prototype.process = function(location, ind, table, rules, addedRules) {
         if (!(this.data === Parser.fail)) {
             // LEO THE LION SAYS GER
             function findLeo(idx, rulename, finalData) {
-                var items = table[idx].map(function(s) {
-                    return s.consumeNonTerminal(rulename);
-                }).filter(function(s) {
-                    return s && s.isComplete() && s.rule.name === rulename;
-                });
+                // performance optimization, avoid high order functions(map/filter) in hotspot code.
+                var items = [];
+                var row = table[idx];
+                for (var col = 0; col < row.length; col++) {
+                    var s = row[col].consumeNonTerminal(rulename);
+                    if (s && s.isComplete() && s.rule.name === rulename) {
+                        items.push(s);
+                    }
+                }
                 if (items.length === 1) {
                     var item = items[0];
                     item.data[item.data.length-1] = finalData;


### PR DESCRIPTION
"findLeo" seems to take 80% of the runtime for a JSON grammar example.

* Avoids iterating over the row twice.
* Avoids the creation of the anonymous function in the map/filter
  high order functions.

Results in Chrome (V8).
X3 speed in JSON Grammar + Tokenizer.
x2 speed in JSON Grammar without Tokenizer.