### PR TITLE
Storing a single item in findLeo instead of a list.

### DIFF
--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -72,16 +72,20 @@ State.prototype.process = function(location, ind, table, rules, addedRules) {
             // LEO THE LION SAYS GER
             function findLeo(idx, rulename, finalData) {
                 // performance optimization, avoid high order functions(map/filter) in hotspot code.
-                var items = [];
+                var item = null;
                 var row = table[idx];
                 for (var col = 0; col < row.length; col++) {
                     var s = row[col].consumeNonTerminal(rulename);
                     if (s && s.isComplete() && s.rule.name === rulename) {
-                        items.push(s);
+                        if (item) {
+                            item = null;
+                            break;
+                        } else {
+                            item = s;
+                        }
                     }
                 }
-                if (items.length === 1) {
-                    var item = items[0];
+                if (item) {
                     item.data[item.data.length-1] = finalData;
                     if (item.reference === idx) {
                         return item;


### PR DESCRIPTION
In findLeo a whole list was being used to store items when all that was needed was to check whether their exists one and only one item in the list. I'm unsure of how I should be checking this for changes in overall speed. 
