### PR TITLE
railroad-diagrams as an optionalDependency

### DIFF
--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -4,7 +4,7 @@ try {
   var rr = require('railroad-diagrams');
 } catch(e) {
   // optional dependency not fullfilled
-  console.log('\u001b[31mOh no!\u001b[39m When you installed nearley, \u001b[31mrailroad-diagrams\u001b[39m failed to install.\n\nTry \u001b[1mnpm install -g nearley\u001b[22m, \u001b[2mand if that doesn\'t work, make an issue on the nearley GitHub repository.\u001b[22m')
+  console.log('Error: When you installed nearley, the dependency "railroad-diagrams" failed to install. Try running "npm install -g nearley" to re-install nearley. If that doesn\'t fix the problem, please file an issue on the nearley GitHub repository.')
   process.exit(1)
 }
 

--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -4,7 +4,7 @@ try {
   var rr = require('railroad-diagrams');
 } catch(e) {
   // optional dependency not fullfilled
-  console.log('\u001b[31mOh no!\u001b[39m When you installed nearley, \u001b[31mrailroad-diagrams\u001b[39m failed to install.\n\nTry \u001b[1mnpm install\u001b[22m again to make it work. \u001b[2mIf that still doesn\'t work, make an issue on the nearley GitHub repository.\u001b[22m')
+  console.log('\u001b[31mOh no!\u001b[39m When you installed nearley, \u001b[31mrailroad-diagrams\u001b[39m failed to install.\n\nTry \u001b[1mnpm install -g nearley\u001b[22m, \u001b[2mand if that doesn\'t work, make an issue on the nearley GitHub repository.\u001b[22m')
   process.exit(1)
 }
 

--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -4,7 +4,8 @@ try {
   var rr = require('railroad-diagrams');
 } catch(e) {
   // optional dependency not fullfilled
-  throw 'railroad-diagrams is not installed'
+  console.log('\u001b[31mOh no!\u001b[39m When you installed nearley, \u001b[31mrailroad-diagrams\u001b[39m failed to install.\n\nTry \u001b[1mnpm install\u001b[22m again to make it work. \u001b[2mIf that still doesn\'t work, make an issue on the nearley GitHub repository.\u001b[22m')
+  process.exit(1)
 }
 
 var fs = require('fs');

--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
 
-var rr = require('railroad-diagrams');
+try {
+  var rr = require('railroad-diagrams');
+} catch(e) {
+  // optional dependency not fullfilled
+  throw 'railroad-diagrams is not installed'
+}
+
 var fs = require('fs');
 var path = require('path');
 var nomnom = require('nomnom');
-
 
 var opts = nomnom
     .script('nearley-railroad')
@@ -38,7 +43,7 @@ function railroad(grm) {
             rules[instr.name] = rules[instr.name].concat(instr.rules);
         }
     });
-    
+
     ret = '<style type="text/css">\n';
     ret += fs.readFileSync(
         path.join(

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "randexp": "^0.4.2"
   },
   "optionalDependencies": {
-    "railroad-diagrams": "git://github.com/tabatkins/railroad-diagrams.git#c36d1a7d0cf5ee2fdd33fcdc849d91f99ee459b9"
+    "railroad-diagrams": "git://github.com/tabatkins/railroad-diagrams.git#c36d1a7d0cf5ee2fdd33fcdc849d91f99ee459b9x"
   },
   "bin": {
     "nearleyc": "bin/nearleyc.js",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "dependencies": {
     "cli-color": "^1.0.0",
     "nomnom": "~1.6.2",
-    "railroad-diagrams": "git://github.com/tabatkins/railroad-diagrams.git#c36d1a7d0cf5ee2fdd33fcdc849d91f99ee459b9",
     "randexp": "^0.4.2"
+  },
+  "optionalDependencies": {
+    "railroad-diagrams": "git://github.com/tabatkins/railroad-diagrams.git#c36d1a7d0cf5ee2fdd33fcdc849d91f99ee459b9"
   },
   "bin": {
     "nearleyc": "bin/nearleyc.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "randexp": "^0.4.2"
   },
   "optionalDependencies": {
-    "railroad-diagrams": "git://github.com/tabatkins/railroad-diagrams.git#c36d1a7d0cf5ee2fdd33fcdc849d91f99ee459b9x"
+    "railroad-diagrams": "git://github.com/tabatkins/railroad-diagrams.git#c36d1a7d0cf5ee2fdd33fcdc849d91f99ee459b9"
   },
   "bin": {
     "nearleyc": "bin/nearleyc.js",


### PR DESCRIPTION
This commit stops `npm install nearley` failing if for whatever reason, `railroad-diagrams` is not installed. (`nearley-railroad` shall throw an error if `railroad-diagrams` is not installed when it is run.)

This resolves #102 and relies on [package.json optionalDependencies](https://docs.npmjs.com/files/package.json#optionaldependencies).