### PR TITLE
Improve HTML output of railroad, including a meta-tag for UTF-8

### DIFF
--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -102,6 +102,7 @@ function railroad(grm) {
     }
 
     return [
+      '<!DOCTYPE html>',
       '<html>',
         '<head>',
           '<meta charset="UTF-8">',

--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -45,20 +45,21 @@ function railroad(grm) {
         }
     });
 
-    ret = '<style type="text/css">\n';
-    ret += fs.readFileSync(
+    var style = fs.readFileSync(
         path.join(
             path.dirname(require.resolve('railroad-diagrams')),
             'railroad-diagrams.css'
         )
-    ).toString();
-    ret += '\n</style>';
+    );
 
-    Object.keys(rules).forEach(function(r) {
-        ret += '\n<br/><h1><code>'+ r +'</code></h1><br/>' + (diagram(r).toString());
+    var diagrams = Object.keys(rules).map(function(r) {
+        return [
+          '<h1><code>' + r + '</code></h1>',
+          '<div>',
+            diagram(r).toString(),
+          '</div>'
+        ].join('\n');
     });
-
-
 
     function diagram(name) {
         var selectedrules = rules[name];
@@ -99,7 +100,20 @@ function railroad(grm) {
 
         return new rr.Diagram([renderTok(outer)]);
     }
-    return ret;
+
+    return [
+      '<html>',
+        '<head>',
+          '<meta charset="UTF-8">',
+          '<style type="text/css">',
+            style.toString(),
+          '</style>',
+        '</head>',
+        '<body>',
+          diagrams.join('\n'),
+        '</body>',
+      '</html>'
+    ].join('\n');
 }
 
 var nearley = require('../lib/nearley.js');


### PR DESCRIPTION
Improving the HTML document produced by `nearley-railroad`. The document now specifies a UTF-8 charset allowing for unicode characters within railroad diagrams to be rendered correctly.