### PR TITLE
Which language is the comment comment about?

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,15 @@ expansions.
 Strings are the *terminals*, which match those string literals (specified as
 JSON-compatible strings).
 
-The following grammar matches a number, a plus sign, and another number
-(anything from a `#` to the end of a line is ignored as a comment):
+The following grammar matches a number, a plus sign, and another number:
 
     expression -> number "+" number
+    
+Anything from a `#` to the end of a line is ignored as a comment:
 
+    expression -> number "+" number # sum of two numbers
+    
+    
 A nonterminal can have multiple expansions, separated by pipes (`|`):
 
     expression ->


### PR DESCRIPTION
Any time you're describing a language for describing a language, it can get confusing.  I found this line in the `README` confusing, because I didn't know whether it meant "You can add a nearley file, `#` starts a comment" or "This grammar defines a language that ignores comments beginning with `#`.  There's no use of `#` in the example that clarifies it.  Based on http://nearley.js.org/www/railroad-demo.html, I'm sure you meant the former, so how about describe it with a second example?