### PR TITLE
Vertical bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ The following grammar matches a number, a plus sign, and another number:
 Anything from a `#` to the end of a line is ignored as a comment:
 
     expression -> number "+" number # sum of two numbers
-    
-    
-A nonterminal can have multiple expansions, separated by pipes (`|`):
+   
+
+A nonterminal can have multiple expansions, separated by vertical bars (`|`):
 
     expression ->
           number "+" number


### PR DESCRIPTION
I know `|` is used by Unix shells to indicate a pipe, but it's also a standard symbol for a disjunction in many programming languages (bitwise _or_, or two for logical _or_), and that's how you're using it in nearley.  This tripped me up when reading this, the same way as it would if you'd said
> To divide two numbers, separate them with a pathname delimiter (`/`)

or if you'd called the comment character a "number sign" or "hash sign" or a "sharp sign", all of which are good names for the octothorpe character in other contexts.