### PR TITLE
Fix for strict mode

### DIFF
--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -98,7 +98,7 @@ State.prototype.process = function(location, ind, table, rules, addedRules) {
                 } else {
                     return false;
                 }
-            }
+            };
 
             var leo = findLeo(this.reference, this.rule.name, this.data);
             if (leo) {

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -69,8 +69,9 @@ State.prototype.process = function(location, ind, table, rules, addedRules) {
             this.data = this.rule.postprocess(this.data, this.reference, Parser.fail);
         }
         if (!(this.data === Parser.fail)) {
+            var findLeo;
             // LEO THE LION SAYS GER
-            function findLeo(idx, rulename, finalData) {
+            findLeo = function findLeo(idx, rulename, finalData) {
                 // performance optimization, avoid high order functions(map/filter) in hotspot code.
                 var items = [];
                 var row = table[idx];


### PR DESCRIPTION
Line 73 causes the following error in strict mode: `In strict mode, function declarations cannot be nested inside a statement or block. They may only appear at the top level or directly inside a function body.`

This is simply fixed by assigning the function to a variable.

Would be good to get this fix in as we are running our entire app in strict mode, and since pulling in nearly, have lost some browser compatibility due to this error.