### PR TITLE
nearley-test: Provide `type: string` on --input option

### DIFF
--- a/bin/nearley-test.js
+++ b/bin/nearley-test.js
@@ -19,6 +19,7 @@ var opts = nomnom
     .option('input', {
         abbr: 'i',
         help: "An input string to parse (if not provided then read from stdin)",
+        type: 'string',
     })
     .option('start', {
         abbr: 's',


### PR DESCRIPTION
Resolves #151.