### PR TITLE
Benchmark suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   ],
   "scripts": {
     "bootstrap": "node bin/nearleyc.js lib/nearley-language-bootstrapped.ne >lib/nearley-language-bootstrapped.js.new && mv lib/nearley-language-bootstrapped.js.new lib/nearley-language-bootstrapped.js",
-    "test": "npm install && mocha test/launch.js"
+    "test": "npm install && mocha test/launch.js",
+    "benchmark": "node test/benchmark.js"
   },
   "author": "Hardmath123",
   "contributors": [
@@ -41,8 +42,11 @@
     "url": "https://github.com/hardmath123/nearley.git"
   },
   "devDependencies": {
+    "benchmark": "^2.1.3",
     "chai": "^3.4.1",
     "coffee-script": "^1.10.0",
+    "colors": "^1.1.2",
+    "microtime": "^2.1.2",
     "mocha": "^2.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "bootstrap": "node bin/nearleyc.js lib/nearley-language-bootstrapped.ne >lib/nearley-language-bootstrapped.js.new && mv lib/nearley-language-bootstrapped.js.new lib/nearley-language-bootstrapped.js",
-    "test": "npm install && mocha test/launch.js",
+    "test": "mocha test/launch.js",
     "benchmark": "node test/benchmark.js"
   },
   "author": "Hardmath123",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "benchmark": "^2.1.3",
     "chai": "^3.4.1",
     "coffee-script": "^1.10.0",
-    "colors": "^1.1.2",
     "microtime": "^2.1.2",
     "mocha": "^2.3.4"
   }

--- a/test/_shared.js
+++ b/test/_shared.js
@@ -1,0 +1,49 @@
+
+var fs = require('fs');
+
+var nearley = require('../lib/nearley.js');
+var Compile = require('../lib/compile.js');
+var parserGrammar = require('../lib/nearley-language-bootstrapped.js');
+var generate = require('../lib/generate.js');
+
+function parse(grammar, input) {
+    if (grammar.should) {
+        grammar.should.have.keys(['ParserRules', 'ParserStart']);
+    }
+    var p = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
+    p.feed(input);
+    return p.results;
+}
+
+function nearleyc(source) {
+    // parse
+    var results = parse(parserGrammar, source);
+
+    // compile
+    var c = Compile(results[0], {});
+
+    // generate
+    var compiledGrammar = generate(c, 'grammar');
+
+    // eval
+    return evalGrammar(compiledGrammar);
+}
+
+function evalGrammar(compiledGrammar) {
+    var f = new Function('module', compiledGrammar);
+    var m = {exports: {}};
+    f(m);
+    return m.exports;
+}
+
+function read(filename) {
+    return fs.readFileSync(filename, 'utf-8');
+}
+
+module.exports = {
+    read: read,
+    nearleyc: nearleyc,
+    parse: parse,
+    evalGrammar: evalGrammar,
+};
+

--- a/test/_shared.js
+++ b/test/_shared.js
@@ -15,7 +15,7 @@ function parse(grammar, input) {
     return p.results;
 }
 
-function nearleyc(source) {
+function compile(source) {
     // parse
     var results = parse(parserGrammar, source);
 
@@ -42,7 +42,7 @@ function read(filename) {
 
 module.exports = {
     read: read,
-    nearleyc: nearleyc,
+    compile: compile,
     parse: parse,
     evalGrammar: evalGrammar,
 };

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -115,6 +115,8 @@ suite.on('cycle', function(event) {
 
   if (bench.error) {
     console.log(colors.red("✘"), bench.name);
+    console.log(colors.red(bench.error.stack));
+    console.log('');
   } else {
     var opsPerSec = formatNumber(hz.toFixed(hz < 100 ? 2 : 0)) + ' ops/sec ' + pm + stats.rme.toFixed(2) + '%';
     console.log(colors.green("✔"), padName(bench.name), colors.blue(opsPerSec));

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -18,40 +18,40 @@ var compile = shared.compile
 // Define benchmarks
 
 function addTest(parserName, parser, exampleInputs) {
-  exampleInputs.forEach(function(inputPath) {
-    var input;
-    var exampleName;
-    if (/^test\//.test(inputPath)) {
-        input = read(inputPath);
-        exampleName = path.basename(inputPath);
-    } else {
-        input = inputPath;
-        exampleName = '"' + input + '"'
-    }
-    suite.add(parserName + ': parse ' + exampleName, function() {
-        parser(input);
-    });
-  })
+    exampleInputs.forEach(function(inputPath) {
+        var input;
+        var exampleName;
+        if (/^test\//.test(inputPath)) {
+            input = read(inputPath);
+            exampleName = path.basename(inputPath);
+        } else {
+            input = inputPath;
+            exampleName = '"' + input + '"':
+        }
+        suite.add(parserName + ': parse ' + exampleName, function() {
+            parser(input);
+        });
+    })
 }
 
 function makeParser(neFile) {
-  var grammar;
-  try {
-    grammar = compile(read(neFile));
-  } catch (e) {
-    grammar = null; // oh dear
-  }
-
-  function parse(input) {
-    if (grammar === null) {
-      throw 'grammar error';
+    var grammar;
+    try {
+        grammar = compile(read(neFile));
+    } catch (e) {
+        grammar = null; // oh dear
     }
-    var p = new Parser(grammar.ParserRules, grammar.ParserStart);
-    p.feed(input)
-    return p.results;
-  }
 
-  return parse;
+    function parse(input) {
+        if (grammar === null) {
+            throw 'grammar error';
+        }
+        var p = new Parser(grammar.ParserRules, grammar.ParserStart);
+        p.feed(input);
+        return p.results;
+    }
+
+    return parse;
 }
 
 
@@ -64,14 +64,14 @@ addTest('calculator example', makeParser('examples/calculator/arithmetic.ne'), [
 ]);
 
 addTest('json example', makeParser('examples/json.ne'), [
-  'test/test1.json',
-  'test/test2.json',
+    'test/test1.json',
+    'test/test2.json',
 ]);
 
 /*
 addTest('native JSON.parse', JSON.parse, [
-  read('test/test1.json'),
-  read('test/test2.json'),
+   'test/test1.json',
+   'test/test2.json',
 ])
 */
 
@@ -79,32 +79,32 @@ addTest('native JSON.parse', JSON.parse, [
 // Run & report results
 
 var longestName = Math.max.apply(null, suite.map(function(bench) {
-  return bench.name.length;
+    return bench.name.length;
 }));
 function padName(x) {
-  while (x.length < longestName) {
-    x += ' ';
-  }
-  return x;
+    while (x.length < longestName) {
+        x += ' ';
+    }
+    return x;
 }
 
 suite.on('cycle', function(event) {
-  var bench = event.target;
-  var stats = bench.stats;
-  var hz = bench.hz; // Hz -- ops per sec
-  var pm = '\xb1';
+    var bench = event.target;
+    var stats = bench.stats;
+    var hz = bench.hz; // Hz -- ops per sec
+    var pm = '\xb1';
 
-  if (bench.error) {
-    console.log(colors.red("✘"), bench.name);
-    console.log(colors.red(bench.error.stack));
-    console.log('');
-  } else {
-    var opsPerSec = formatNumber(hz.toFixed(hz < 100 ? 2 : 0)) + ' ops/sec ' + pm + stats.rme.toFixed(2) + '%';
-    console.log(colors.green("✔"), padName(bench.name), colors.blue(opsPerSec));
-  }
+    if (bench.error) {
+        console.log(colors.red("✘"), bench.name);
+        console.log(colors.red(bench.error.stack));
+        console.log('');
+    } else {
+        var opsPerSec = formatNumber(hz.toFixed(hz < 100 ? 2 : 0)) + ' ops/sec ' + pm + stats.rme.toFixed(2) + '%';
+        console.log(colors.green("✔"), padName(bench.name), colors.blue(opsPerSec));
+    }
 })
 .on('complete', function() {
-  // TODO: report geometric mean.
+    // TODO: report geometric mean.
 })
 .run();
 

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,13 +1,7 @@
 
-var fs = require('fs');
 var path = require('path');
-var child_process = require('child_process')
 
 var Benchmark = require('benchmark');
-var colors = require('colors/safe');
-
-var formatNumber = Benchmark.formatNumber;
-var suite = new Benchmark.Suite();
 
 var Parser = require('../lib/nearley.js').Parser;
 var shared = require('./_shared.js');
@@ -15,20 +9,12 @@ var compile = shared.compile
   , read = shared.read;
 
 
-// Define benchmarks
+// For making tests
 
-function addTest(parserName, parser, exampleInputs) {
-    exampleInputs.forEach(function(inputPath) {
-        var input;
-        var exampleName;
-        if (/^test\//.test(inputPath)) {
-            input = read(inputPath);
-            exampleName = path.basename(inputPath);
-        } else {
-            input = inputPath;
-            exampleName = '"' + input + '"';
-        }
-        suite.add(parserName + ': parse ' + exampleName, function() {
+function addTest(parserName, parser, examples) {
+    examples.forEach(function(example) {
+        var input = example.source;
+        suite.add(parserName + ' ' + example.name, function() {
             parser(input);
         });
     })
@@ -54,53 +40,49 @@ function makeParser(neFile) {
     return parse;
 }
 
+function Example(name, source) {
+    this.name = name;
+    this.source = source;
+}
 
-// TODO benchmark compile
+Example.read = function(filename) {
+  return new Example(path.basename(filename), read(filename));
+};
 
+// Define benchmarks
 
-addTest('calculator example', makeParser('examples/calculator/arithmetic.ne'), [
-    '2 + 3 * 42 - sin(0.14)',
-    'ln (3 + 2*(8/e - sin(pi/5)))',
+var suite = new Benchmark.Suite();
+
+addTest('calculator', makeParser('examples/calculator/arithmetic.ne'), [
+    new Example('arithmetic1', '2 + 3 * 42 - sin(0.14)'),
+    new Example('arithmetic2', 'ln (3 + 2*(8/e - sin(pi/5)))'),
 ]);
 
-addTest('json example', makeParser('examples/json.ne'), [
-    'test/test1.json',
-    'test/test2.json',
+addTest('json', makeParser('examples/json.ne'), [
+    Example.read('test/test1.json'),
+    Example.read('test/test2.json'),
 ]);
 
 /*
 addTest('native JSON.parse', JSON.parse, [
-   'test/test1.json',
-   'test/test2.json',
+   Example.read('test/test1.json'),
+   Example.read('test/test2.json'),
 ])
 */
+
+// TODO benchmark compile
 
 
 // Run & report results
 
-var longestName = Math.max.apply(null, suite.map(function(bench) {
-    return bench.name.length;
-}));
-function padName(x) {
-    while (x.length < longestName) {
-        x += ' ';
-    }
-    return x;
-}
-
 suite.on('cycle', function(event) {
     var bench = event.target;
-    var stats = bench.stats;
-    var hz = bench.hz; // Hz -- ops per sec
-    var pm = '\xb1';
-
     if (bench.error) {
-        console.log(colors.red("✘"), bench.name);
-        console.log(colors.red(bench.error.stack));
+        console.log('  ✘ ', bench.name);
+        console.log(bench.error.stack);
         console.log('');
     } else {
-        var opsPerSec = formatNumber(hz.toFixed(hz < 100 ? 2 : 0)) + ' ops/sec ' + pm + stats.rme.toFixed(2) + '%';
-        console.log(colors.green("✔"), padName(bench.name), colors.blue(opsPerSec));
+        console.log('  ✔ ' + bench)
     }
 })
 .on('complete', function() {

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -19,10 +19,17 @@ var compile = shared.compile
 
 function addTest(parserName, parser, exampleInputs) {
   exampleInputs.forEach(function(inputPath) {
-    var input = read(inputPath);
-
-    suite.add(parserName + ': parse ' + path.basename(inputPath), function() {
-      parser(input);
+    var input;
+    var exampleName;
+    if (/^test\//.test(inputPath)) {
+        input = read(inputPath);
+        exampleName = path.basename(inputPath);
+    } else {
+        input = inputPath;
+        exampleName = '"' + input + '"'
+    }
+    suite.add(parserName + ': parse ' + exampleName, function() {
+        parser(input);
     });
   })
 }
@@ -50,15 +57,23 @@ function makeParser(neFile) {
 
 // TODO benchmark compile
 
+
+addTest('calculator example', makeParser('examples/calculator/arithmetic.ne'), [
+    '2 + 3 * 42 - sin(0.14)',
+    'ln (3 + 2*(8/e - sin(pi/5)))',
+]);
+
 addTest('json example', makeParser('examples/json.ne'), [
   'test/test1.json',
   'test/test2.json',
-])
+]);
 
+/*
 addTest('native JSON.parse', JSON.parse, [
-  'test/test1.json',
-  'test/test2.json',
+  read('test/test1.json'),
+  read('test/test2.json'),
 ])
+*/
 
 
 // Run & report results

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -26,7 +26,7 @@ function addTest(parserName, parser, exampleInputs) {
             exampleName = path.basename(inputPath);
         } else {
             input = inputPath;
-            exampleName = '"' + input + '"':
+            exampleName = '"' + input + '"';
         }
         suite.add(parserName + ': parse ' + exampleName, function() {
             parser(input);

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,23 +1,101 @@
 
+var fs = require('fs');
+var path = require('path');
+var child_process = require('child_process')
+
 var Benchmark = require('benchmark');
 var colors = require('colors/safe');
 
 var formatNumber = Benchmark.formatNumber;
-var suite = new Benchmark.Suite({
-});
+var suite = new Benchmark.Suite();
+
+var nearley = require('../lib/nearley.js');
 
 
 
-// add tests
-suite.add('RegExp#test', function() {
-  /o/.test('Hello World!');
-})
-.add('String#indexOf', function() {
-  'Hello World!'.indexOf('o') > -1;
-})
-.add('String#match', function() {
-  !!'Hello World!'.match(/o/);
-})
+function read(path) {
+  return fs.readFileSync(path, 'utf-8')
+}
+
+
+/* from launch.js --TODO share code? */
+function sh(cmd) {
+    return child_process.execSync(cmd, {encoding: 'utf-8', stdio: 'pipe'});
+}
+
+function nearleyc(args) {
+    return sh("node bin/nearleyc.js " + args);
+}
+
+function load(compiledGrammar) {
+    var f = new Function('module', compiledGrammar);
+    var m = {exports: {}};
+    f(m);
+    return m.exports;
+}
+
+function loadFile(compiledFilename) {
+    return load(read(compiledFilename));
+}
+
+function parse(grammar, input) {
+    if (typeof grammar == 'string') {
+        if (grammar.match(/\.js$/)) grammar = loadFile(grammar);
+        else grammar = load(grammar);
+    }
+    grammar.should.have.keys(['ParserRules', 'ParserStart']);
+    var p = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
+    return p.feed(input).results;
+}
+
+
+// Define benchmarks
+
+function addTest(parserName, parser, exampleInputs) {
+  exampleInputs.forEach(function(inputPath) {
+    var input = read(inputPath);
+
+    suite.add(parserName + ': parse ' + path.basename(inputPath), function() {
+      parser(input);
+    });
+  })
+}
+
+function makeParser(neFile) {
+  var grammar;
+  try {
+    var out = nearleyc(neFile);
+    grammar = load(out);
+  } catch (e) {
+    grammar = null; // oh dear
+  }
+
+  function parse(input) {
+    if (grammar === null) {
+      throw 'grammar error';
+    }
+    var p = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
+    return p.feed(input).results;
+  }
+
+  return parse;
+}
+
+
+// TODO benchmark nearleyc [without using sh!]
+
+addTest('json example', makeParser('examples/json.ne'), [
+  'test/test1.json',
+  'test/test2.json',
+])
+
+addTest('native JSON.parse', JSON.parse, [
+  'test/test1.json',
+  'test/test2.json',
+])
+
+
+// Run & report results
 
 var longestName = Math.max.apply(null, suite.map(function(bench) {
   return bench.name.length;
@@ -29,7 +107,6 @@ function padName(x) {
   return x;
 }
 
-// add listeners
 suite.on('cycle', function(event) {
   var bench = event.target;
   var stats = bench.stats;
@@ -44,8 +121,7 @@ suite.on('cycle', function(event) {
   }
 })
 .on('complete', function() {
-  // console.log('Fastest is ' + this.filter('fastest').map('name'));
+  // TODO: report geometric mean.
 })
-// run async
-.run({ 'async': true });
+.run();
 

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -11,7 +11,7 @@ var suite = new Benchmark.Suite();
 
 var Parser = require('../lib/nearley.js').Parser;
 var shared = require('./_shared.js');
-var nearleyc = shared.nearleyc
+var compile = shared.compile
   , read = shared.read;
 
 
@@ -30,7 +30,7 @@ function addTest(parserName, parser, exampleInputs) {
 function makeParser(neFile) {
   var grammar;
   try {
-    grammar = nearleyc(read(neFile));
+    grammar = compile(read(neFile));
   } catch (e) {
     grammar = null; // oh dear
   }
@@ -48,7 +48,7 @@ function makeParser(neFile) {
 }
 
 
-// TODO benchmark nearleyc [without using sh!]
+// TODO benchmark compile
 
 addTest('json example', makeParser('examples/json.ne'), [
   'test/test1.json',

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,0 +1,51 @@
+
+var Benchmark = require('benchmark');
+var colors = require('colors/safe');
+
+var formatNumber = Benchmark.formatNumber;
+var suite = new Benchmark.Suite({
+});
+
+
+
+// add tests
+suite.add('RegExp#test', function() {
+  /o/.test('Hello World!');
+})
+.add('String#indexOf', function() {
+  'Hello World!'.indexOf('o') > -1;
+})
+.add('String#match', function() {
+  !!'Hello World!'.match(/o/);
+})
+
+var longestName = Math.max.apply(null, suite.map(function(bench) {
+  return bench.name.length;
+}));
+function padName(x) {
+  while (x.length < longestName) {
+    x += ' ';
+  }
+  return x;
+}
+
+// add listeners
+suite.on('cycle', function(event) {
+  var bench = event.target;
+  var stats = bench.stats;
+  var hz = bench.hz; // Hz -- ops per sec
+  var pm = '\xb1';
+
+  if (bench.error) {
+    console.log(colors.red("✘"), bench.name);
+  } else {
+    var opsPerSec = formatNumber(hz.toFixed(hz < 100 ? 2 : 0)) + ' ops/sec ' + pm + stats.rme.toFixed(2) + '%';
+    console.log(colors.green("✔"), padName(bench.name), colors.blue(opsPerSec));
+  }
+})
+.on('complete', function() {
+  // console.log('Fastest is ' + this.filter('fastest').map('name'));
+})
+// run async
+.run({ 'async': true });
+

--- a/test/launch.js
+++ b/test/launch.js
@@ -49,7 +49,7 @@ describe("nearleyc", function() {
     });
 
     it('exponential whitespace bug', function() {
-        sh("node bin/nearleyc.js test/indentation.ne");
+        compile(read('test/indentation.ne'));
     });
 
     it('nullable whitespace bug', function() {
@@ -60,7 +60,7 @@ describe("nearleyc", function() {
     });
 
     it('percent bug', function() {
-        sh("node bin/nearleyc.js test/percent.ne");
+        compile(read('test/percent.ne'));
     });
 
     it('tokens', function() {

--- a/test/launch.js
+++ b/test/launch.js
@@ -3,7 +3,7 @@ var child_process = require('child_process')
   , mocha = require('mocha');
 
 var shared = require('./_shared.js');
-var nearleyc = shared.nearleyc
+var compile = shared.compile
   , evalGrammar = shared.evalGrammar
   , parse = shared.parse
   , read = shared.read;
@@ -34,13 +34,13 @@ describe("nearleyc", function() {
     });
 
     it('calculator example', function() {
-        var arith = nearleyc(read("examples/calculator/arithmetic.ne"));
+        var arith = compile(read("examples/calculator/arithmetic.ne"));
         parse(arith, "ln (3 + 2*(8/e - sin(pi/5)))")
             .should.deep.equal([ Math.log(3 + 2*(8/Math.exp(1) - Math.sin(Math.PI/5))) ]);
     });
 
     it('csscolor example', function() {
-        var cssc = nearleyc(read("examples/csscolor.ne"));
+        var cssc = compile(read("examples/csscolor.ne"));
         parse(cssc, "#FF00FF").should.deep.equal([{r: 0xff, g: 0x00, b: 0xff}]);
         parse(cssc, "#8A7").should.deep.equal([{r: 0x88, g: 0xaa, b: 0x77}]);
         parse(cssc, "rgb(99,66,33)").should.deep.equal([{r: 99, g: 66, b: 33}]);
@@ -53,7 +53,7 @@ describe("nearleyc", function() {
     });
 
     it('nullable whitespace bug', function() {
-        var wsb = nearleyc(read("test/whitespace.ne"));
+        var wsb = compile(read("test/whitespace.ne"));
         parse(wsb, "(x)")
             .should.deep.equal(
             [ [ [ [ '(', null, [ [ [ [ 'x' ] ] ] ], null, ')' ] ] ] ]);
@@ -64,12 +64,12 @@ describe("nearleyc", function() {
     });
 
     it('tokens', function() {
-        var tokc = nearleyc(read("examples/token.ne"));
+        var tokc = compile(read("examples/token.ne"));
         parse(tokc, [123, 456, " ", 789]).should.deep.equal([ [123, [ [ 456, " ", 789 ] ]] ]);
     });
 
     it('leo bug', function() {
-        var leo = nearleyc(read("test/leobug.ne"));
+        var leo = compile(read("test/leobug.ne"));
         parse(leo, "baab")
             .should.deep.equal(
             [ [ 'b', [], 'a', [], 'a', [ 'b' ] ],
@@ -78,7 +78,7 @@ describe("nearleyc", function() {
 
     var json;
     it('json example compiles', function() {
-        json = nearleyc(read("examples/json.ne"));
+        json = compile(read("examples/json.ne"));
     });
     it('json test1', function() {
         var test1 = read('test/test1.json');
@@ -90,7 +90,7 @@ describe("nearleyc", function() {
     });
 
     it('tosh example', function() {
-        var tosh = nearleyc(read("examples/tosh.ne"));
+        var tosh = compile(read("examples/tosh.ne"));
         parse(tosh, "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))")
             .should.deep.equal([["setVar:to:","foo",["*",["*",2,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]],["-",1,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]]]]]);
     });

--- a/test/launch.js
+++ b/test/launch.js
@@ -1,10 +1,12 @@
-var fs = require('fs')
-  , child_process = require('child_process')
+var child_process = require('child_process')
   , chai = require('chai')
   , mocha = require('mocha');
 
-var nearley = require('../lib/nearley.js');
-
+var shared = require('./_shared.js');
+var nearleyc = shared.nearleyc
+  , evalGrammar = shared.evalGrammar
+  , parse = shared.parse
+  , read = shared.read;
 
 chai.should();
 
@@ -12,51 +14,33 @@ function sh(cmd) {
     return child_process.execSync(cmd, {encoding: 'utf-8', stdio: 'pipe'});
 }
 
-function nearleyc(args) {
+function externalNearleyc(args) {
     return sh("node bin/nearleyc.js " + args);
 }
 
-function load(compiledGrammar) {
-    var f = new Function('module', compiledGrammar);
-    var m = {exports: {}};
-    f(m);
-    return m.exports;
-}
 
-function loadFile(compiledFilename) {
-    return load(fs.readFileSync(compiledFilename, 'utf-8'));
-}
-
-function parse(grammar, input) {
-    if (typeof grammar == 'string') {
-        if (grammar.match(/\.js$/)) grammar = loadFile(grammar);
-        else grammar = load(grammar);
-    }
-    grammar.should.have.keys(['ParserRules', 'ParserStart']);
-    var p = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
-    return p.feed(input).results;
-}
 
 describe("nearleyc", function() {
     it('should build test parser (check integrity)', function() {
-        nearleyc("test/parens.ne -o test/parens.js").should.equal("");
+        externalNearleyc("test/parens.ne -o test/parens.js").should.equal("");
     });
 
     it('should build for CoffeeScript', function() {
-        nearleyc("test/coffeescript-test.ne -o test/tmp.coffeescript-test.coffee").should.equal("");
+        externalNearleyc("test/coffeescript-test.ne -o test/tmp.coffeescript-test.coffee").should.equal("");
         sh("coffee -c test/tmp.coffeescript-test.coffee");
-        parse("test/tmp.coffeescript-test.js", "ABCDEFZ12309")
+        var grammar = evalGrammar(read("test/tmp.coffeescript-test.js"));
+        parse(grammar, "ABCDEFZ12309")
             .should.deep.equal([ [ 'ABCDEFZ', '12309' ] ]);
     });
 
     it('calculator example', function() {
-        var arith = nearleyc("examples/calculator/arithmetic.ne");
+        var arith = nearleyc(read("examples/calculator/arithmetic.ne"));
         parse(arith, "ln (3 + 2*(8/e - sin(pi/5)))")
             .should.deep.equal([ Math.log(3 + 2*(8/Math.exp(1) - Math.sin(Math.PI/5))) ]);
     });
 
     it('csscolor example', function() {
-        var cssc = load(nearleyc("examples/csscolor.ne"));
+        var cssc = nearleyc(read("examples/csscolor.ne"));
         parse(cssc, "#FF00FF").should.deep.equal([{r: 0xff, g: 0x00, b: 0xff}]);
         parse(cssc, "#8A7").should.deep.equal([{r: 0x88, g: 0xaa, b: 0x77}]);
         parse(cssc, "rgb(99,66,33)").should.deep.equal([{r: 99, g: 66, b: 33}]);
@@ -69,7 +53,7 @@ describe("nearleyc", function() {
     });
 
     it('nullable whitespace bug', function() {
-        var wsb = nearleyc("test/whitespace.ne");
+        var wsb = nearleyc(read("test/whitespace.ne"));
         parse(wsb, "(x)")
             .should.deep.equal(
             [ [ [ [ '(', null, [ [ [ [ 'x' ] ] ] ], null, ')' ] ] ] ]);
@@ -80,12 +64,12 @@ describe("nearleyc", function() {
     });
 
     it('tokens', function() {
-        var tokc = load(nearleyc("examples/token.ne"));
+        var tokc = nearleyc(read("examples/token.ne"));
         parse(tokc, [123, 456, " ", 789]).should.deep.equal([ [123, [ [ 456, " ", 789 ] ]] ]);
     });
 
     it('leo bug', function() {
-        var leo = nearleyc("test/leobug.ne");
+        var leo = nearleyc(read("test/leobug.ne"));
         parse(leo, "baab")
             .should.deep.equal(
             [ [ 'b', [], 'a', [], 'a', [ 'b' ] ],
@@ -94,19 +78,19 @@ describe("nearleyc", function() {
 
     var json;
     it('json example compiles', function() {
-        json = nearleyc("examples/json.ne");
+        json = nearleyc(read("examples/json.ne"));
     });
     it('json test1', function() {
-        var test1 = fs.readFileSync('test/test1.json', 'utf-8');
+        var test1 = read('test/test1.json');
         parse(json, test1).should.deep.equal([JSON.parse(test1)]);
     });
     it('json test2', function() {
-        var test2 = fs.readFileSync('test/test2.json', 'utf-8');
+        var test2 = read('test/test2.json');
         parse(json, test2).should.deep.equal([JSON.parse(test2)]);
     });
 
     it('tosh example', function() {
-        var tosh = nearleyc("examples/tosh.ne");
+        var tosh = nearleyc(read("examples/tosh.ne"));
         parse(tosh, "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))")
             .should.deep.equal([["setVar:to:","foo",["*",["*",2,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]],["-",1,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]]]]]);
     });


### PR DESCRIPTION
Today's patch: adding a lil benchmark suite.

Yes, benchmarking nearley's JSON example against a native JSON parser is
hilarious and stupid. But it demonstrates that the benchmarks work (-:

I've also refactored the existing tests to invoke nearleyc directly, rather than through a subprocess. This makes `npm test` a fair bit faster (4s -> 2s over here).

@hardmath123 What do you think? :-)

---

    $ npm run benchmark