### PR TITLE
Left-recursive EBNF expansion

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -200,8 +200,8 @@ function Compile(structure, opts) {
             [{
                 tokens: [token.ebnf],
             }, {
-                tokens: [token.ebnf, name],
-                postprocess: {builtin: "arrconcat"}
+                tokens: [name, token.ebnf],
+                postprocess: {builtin: "arrpush"}
             }],
             env
         );
@@ -225,8 +225,8 @@ function Compile(structure, opts) {
             [{
                 tokens: [],
             }, {
-                tokens: [token.ebnf, name],
-                postprocess: {builtin: "arrconcat"}
+                tokens: [name, token.ebnf],
+                postprocess: {builtin: "arrpush"}
             }],
             env
         );

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -123,6 +123,7 @@ generate.js = generate._default = generate.javascript = function (parser, export
 generate.javascript.builtinPostprocessors = {
     "joiner": "function joiner(d) {return d.join('');}",
     "arrconcat": "function arrconcat(d) {return [d[0]].concat(d[1]);}",
+    "arrpush": "function arrpush(d) {return d[0].concat([d[1]]);}",
     "nuller": "function(d) {return null;}",
     "id": "id"
 }
@@ -152,6 +153,7 @@ generate.cs = generate.coffee = generate.coffeescript = function (parser, export
 generate.coffeescript.builtinPostprocessors = {
     "joiner": "(d) -> d.join('')",
     "arrconcat": "(d) -> [d[0]].concat(d[1])",
+    "arrpush": "(d) -> d[0].concat([d[1]])",
     "nuller": "() -> null",
     "id": "id"
 }


### PR DESCRIPTION
When testing #171 I found I was running out of memory when parsing a large JSON sample (~1kB), using the example scannerless JSON parser in the repo.

I realised that we're expanding EBNF rules like
```
string -> "\"" validChar:* "\""
```
into
```
string$ebnf$1 -> 
               | validChar string$ebnf$1
```

Since Earley loves left-recursion, I think it would be better to expand these left-recursively instead! In particular, I *think* this avoids some weird n^2 behaviour when parsing long strings.

Anyway, even on master this patch appears to speed up a 1k JSON sample by ~3x, so this seems worthwhile :-)

@hardmath123 What do you think?