### PR TITLE
Add history option & refactor Grammar construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,11 +290,13 @@ Using a parser
 
 nearley exposes the following API:
 
-    var grammar = require("generated-code.js");
+    var generated = require("generated-code.js");
     var nearley = require("nearley");
 
+    var grammar = nearley.Grammar.fromCompiled(generated)
+
     // Create a Parser object from our grammar.
-    var p = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
+    var p = new nearley.Parser(grammar);
 
     // Parse something
     p.feed("1+1");
@@ -315,6 +317,17 @@ complete block.
         p.feed(prompt_user("... "));
     }
     console.log(p.results);
+
+The parse table
+---------------
+
+Advanced people might like to poke inside the parser to look at the Earley parse table, in order to do advanced things. By default nearley doesn't keep the table around, to save memory. To access it you first need to turn on the `keepHistory` option:
+
+    var p = new nearley.Parser(grammar, {
+        keepHistory: true,
+    });
+
+Then you can get at the parse table using `p.table` after parsing.
 
 Catching errors
 ---------------

--- a/bin/nearley-test.js
+++ b/bin/nearley-test.js
@@ -47,21 +47,21 @@ var opts = nomnom
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
 var grammar = new require(require('path').resolve(opts.file));
-var parser = new nearley.Parser(grammar.ParserRules, opts.start ? opts.start : grammar.ParserStart);
+var parser = new nearley.Parser(grammar.ParserRules, opts.start ? opts.start : grammar.ParserStart, {
+    history: true,
+});
 
 var writeTable = function (writeStream, parser) {
     writeStream.write("Table length: " + parser.table.length + "\n");
     writeStream.write("Number of parses: " + parser.results.length + "\n");
     writeStream.write("Parse Charts");
-    parser.table.forEach(
-        function (column, chartNumber) {
-            console.log(column);
-            writeStream.write("\nChart: " + chartNumber++ + "\n");
-            column.states.forEach(
-                function (state, stateNumber) {
-                    writeStream.write(stateNumber++ + ": " + state.toString() + "\n");
-                } )
-        } )
+    parser.table.forEach(function (column, index) {
+        writeStream.write("\nChart: " + index++ + "\n");
+        var stateNumber = 0;
+        column.states.forEach(function (state, stateIndex) {
+            writeStream.write(stateIndex + ": " + state.toString() + "\n");
+        })
+    })
     writeStream.write("\n\nParse results: \n");
 }
 

--- a/bin/nearley-test.js
+++ b/bin/nearley-test.js
@@ -48,7 +48,7 @@ var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
 var grammar = new require(require('path').resolve(opts.file));
 var parser = new nearley.Parser(grammar.ParserRules, opts.start ? opts.start : grammar.ParserStart, {
-    history: true,
+    keepHistory: true,
 });
 
 var writeTable = function (writeStream, parser) {

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -190,13 +190,13 @@ function Parser(rules, start, options) {
 
     // Read options
     this.options = {
-        history: false,
+        keepHistory: false,
         // rewindable: false,
     };
     for (var key in (options || {})) {
         this.options[key] = options[key];
     }
-    // if (this.options.rewindable) { this.options.history = true; }
+    // if (this.options.rewindable) { this.options.keepHistory = true; }
 
     // Setup a table
     var column = new Column(grammar, 0);
@@ -219,7 +219,7 @@ Parser.prototype.feed = function(chunk) {
         var column = this.table[this.current + chunkPos];
 
         // GC unused states
-        if (!this.options.history) {
+        if (!this.options.keepHistory) {
             delete this.table[this.current + chunkPos - 1];
         }
 

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -157,7 +157,7 @@ Column.prototype.complete = function(left, right) {
 
 
 function Grammar(rules, start) {
-    this.rules = rules.map(function (r) { return (new Rule(r.name, r.symbols, r.postprocess)); });
+    this.rules = rules;
     this.start = start || this.rules[0].name;
     var byName = this.byName = {};
     this.rules.forEach(function(rule) {
@@ -168,10 +168,19 @@ function Grammar(rules, start) {
     });
 }
 
+// So we can allow passing (rules, start) directly to Parser for backwards compatibility
+Grammar.fromCompiled = function(rules, start) {
+    if (rules.ParserStart) {
+      start = rules.ParserStart;
+      rules = rules.ParserRules;
+    }
+    var rules = rules.map(function (r) { return (new Rule(r.name, r.symbols, r.postprocess)); });
+    return new Grammar(rules, start);
+}
+
 
 function Parser(rules, start) {
-    //var grammar = this.grammar = rules instanceof Grammar ? rules : new Grammar(rules, start);
-    var grammar = this.grammar = new Grammar(rules, start);
+    var grammar = this.grammar = rules instanceof Grammar ? rules : Grammar.fromCompiled(rules, start);
 
     // Setup a table
     var column = new Column(grammar, 0);

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -179,8 +179,24 @@ Grammar.fromCompiled = function(rules, start) {
 }
 
 
-function Parser(rules, start) {
-    var grammar = this.grammar = rules instanceof Grammar ? rules : Grammar.fromCompiled(rules, start);
+function Parser(rules, start, options) {
+    if (rules instanceof Grammar) {
+        var grammar = rules;
+        var options = start;
+    } else {
+        var grammar = Grammar.fromCompiled(rules, start);
+    }
+    this.grammar = grammar;
+
+    // Read options
+    this.options = {
+        history: false,
+        // rewindable: false,
+    };
+    for (var key in (options || {})) {
+        this.options[key] = options[key];
+    }
+    // if (this.options.rewindable) { this.options.history = true; }
 
     // Setup a table
     var column = new Column(grammar, 0);
@@ -203,7 +219,9 @@ Parser.prototype.feed = function(chunk) {
         var column = this.table[this.current + chunkPos];
 
         // GC unused states
-        delete this.table[this.current + chunkPos - 1];
+        if (!this.options.history) {
+            delete this.table[this.current + chunkPos - 1];
+        }
 
         var n = this.current + chunkPos + 1;
         var nextColumn = new Column(this.grammar, n);

--- a/test/_shared.js
+++ b/test/_shared.js
@@ -3,11 +3,11 @@ var fs = require('fs');
 
 var nearley = require('../lib/nearley.js');
 var Compile = require('../lib/compile.js');
-var parserGrammar = require('../lib/nearley-language-bootstrapped.js');
+var parserGrammar = nearley.Grammar.fromCompiled(require('../lib/nearley-language-bootstrapped.js'));
 var generate = require('../lib/generate.js');
 
 function parse(grammar, input) {
-    var p = new nearley.Parser(grammar.ParserRules, grammar.ParserStart);
+    var p = new nearley.Parser(grammar);
     p.feed(input);
     return p.results;
 }
@@ -30,7 +30,7 @@ function evalGrammar(compiledGrammar) {
     var f = new Function('module', compiledGrammar);
     var m = {exports: {}};
     f(m);
-    return m.exports;
+    return new nearley.Grammar.fromCompiled(m.exports);
 }
 
 function read(filename) {
@@ -38,6 +38,7 @@ function read(filename) {
 }
 
 module.exports = {
+    nearley: nearley,
     read: read,
     compile: compile,
     parse: parse,

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -32,7 +32,7 @@ function makeParser(neFile) {
         if (grammar === null) {
             throw 'grammar error';
         }
-        var p = new Parser(grammar.ParserRules, grammar.ParserStart);
+        var p = new Parser(grammar);
         p.feed(input);
         return p.results;
     }

--- a/test/launch.js
+++ b/test/launch.js
@@ -4,6 +4,7 @@ var child_process = require('child_process')
 
 var shared = require('./_shared.js');
 var compile = shared.compile
+  , nearley = shared.nearley
   , evalGrammar = shared.evalGrammar
   , parse = shared.parse
   , read = shared.read;


### PR DESCRIPTION
First, we allow Parser to accept a Grammar directly. This is the preferred way, since it avoids constructing the Grammar every time we want to parse something (which has a cost O(n) in the size of the grammar). I've modified the benchmarks to cache the Grammar object, so there should be a minor speed bump there (should be more for larger grammars I guess?).

To make the tests easier to write, I added `Grammar.fromCompiled()`. There are thus three ways to get a grammar:

    Grammar(rules, start) // note: list of Rule objects
    Grammar.fromCompiled({ParserRules,ParserStart})
    Grammar.fromCompiled(ParserRules, ParserStart)

This is also used for backwards-compatibility in the Parser constructor, so you can still construct a Parser the old way (even though caching your Grammar is preferred).

Then, we add a lightweight options dict to Parser, containing a sole `history` option. If it is true, we include all the columns in the Earley table, disabling the memory optimisation that removes old unusued states.

So parser can now be initialised four ways:

    Parser(Grammar)
    Parser(Grammar, options)
    Parser(ParserRules, ParserStart)
    Parser(ParserRules, ParserStart, options)
