### PR TITLE
Added grammar for COOL recursive comments

### DIFF
--- a/examples/cool_comments.ne
+++ b/examples/cool_comments.ne
@@ -1,0 +1,23 @@
+# Grammar for parsing content of recursive comments of COOL (The Classroom Object-Oriented Language)
+# Treat everything inside the outmost (**) as content
+# Empty comment: (**)
+# Recursive comments: (*(**)*) => (**), (*(*a*)(*b*)*) => (*a*)(*b*)
+# Invalid comments: (*)*), (*(*), (*(**), (*(*)*)
+# For details, check: http://theory.stanford.edu/~aiken/software/cool/cool.html
+
+@{% function wrap(str) { return "(*" + str + "*)"; } %}
+
+comment -> "(*" commentContent:* "*)" {% function(d) { return d[1].join(""); } %}
+
+commentContent ->
+      validCommentChar {% id %}
+    | comment {% function(d) { return wrap(d[0]); } %}
+    | "(":+ comment {% function(d) { return d[0].join("") + wrap(d[1]); } %}
+    | comment ")":+ {% function(d) { return wrap(d[0]) + d[1].join(""); } %}
+    | "(":+ comment ")":+ {% function(d) { return d[0].join("") + wrap(d[1]) + d[2].join(""); } %}
+
+validCommentChar ->
+      [^\(\)] {% id %}
+    | "(":+ [^\*\(\)] {% function(d) { return d[0].join("") + d[1]; } %}
+    | [^\*\(\)] ")":+ {% function(d) { return d[0] + d[1].join(""); } %}
+    | "(":+ [^\*\(\)]:? ")":+ {% function(d) { return d[0].join("") + (d[1] || '') + d[2].join(""); } %}

--- a/test/launch.js
+++ b/test/launch.js
@@ -143,4 +143,39 @@ describe("nearleyc", function() {
         parse(parentheses, '').should.deep.equal([]);
         parse(parentheses, '((((())))(())()').should.deep.equal([]);
     });
+
+    it('COOL recursive comments', function() {
+        // Try compiling the grammar
+        var coolComments = compile(read("examples/cool_comments.ne"));
+        var passCases = [
+            '(**)',
+            '(*(*a*)(*b*)*)',
+            '(*((* )*)))*)',
+            '(*(**)))(**)*)',
+            '(*(*(#)*)_((((*(>)*)))))*)',
+            '(*(*(**))()(((((((*((**)*)*)*)',
+            '(*(((**))(((*((**)(((*;)*))*)(*(*E)*)(**))))((*((**)(**)*)*))))((((X*)'
+        ];
+
+        for (let i in passCases) {
+            parse(coolComments, passCases[i]).should.deep.equal(
+                // Remove the outmost (**)
+                [passCases[i].substr(2, passCases[i].length - 4)]
+            );
+        }
+
+        var failCases = [
+            ' ',
+            '(*)*)',
+            '(*(*)*)'
+        ];
+
+        for (let i in failCases) {
+            (function() { parse(coolComments, failCases[i]); }).should.throw(Error);
+        }
+
+        // These are invalid inputs but the parser will not complain
+        parse(coolComments, '').should.deep.equal([]);
+        parse(coolComments, '(*(**)').should.deep.equal([]);
+    });
 });


### PR DESCRIPTION
Grammar for parsing content of recursive comments of COOL (The Classroom Object-Oriented Language)

* Treat everything inside the outmost (**) as content
* Empty comment: `(**)`
* Recursive comments: `(*(**)*)` => `(**)`, `(*(*a*)(*b*)*)` => `(*a*)(*b*)`
* Invalid comments: `(*)*)`, `(*(*)`, `(*(**)`, `(*(*)*)`
* For details, check: http://theory.stanford.edu/~aiken/software/cool/cool.html