### PR TITLE
Add rewind()

### DIFF
--- a/examples/tosh.ne
+++ b/examples/tosh.ne
@@ -386,7 +386,7 @@ block -> "else" {% d => ["else"] %}
 _ -> [ ]:* {% d => null %}
 __ -> [ ]:+ {% d => null %}
 
-string -> "'hello'"
+string -> "'hello'"             {% d => 'hello' %}
 number -> digits                {% d => parseInt(d[0]) %}
 number -> digits [.] digits     {% d => parseFloat(d.join('')) %}
 

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -267,11 +267,32 @@ Parser.prototype.feed = function(chunk) {
     }
 
     this.current += chunkPos;
+
     // Incrementally keep track of results
     this.results = this.finish();
 
     // Allow chaining, for whatever it's worth
     return this;
+};
+
+Parser.prototype.rewind = function(index) {
+    if (!this.options.keepHistory) {
+        throw new Error('set option `keepHistory` to enable rewinding')
+    }
+    if (this.current < this.index) {
+        // TODO: api -- consider silently succeeding?
+        throw new Error('cannot rewind forward!')
+    }
+    /*
+     * recall column (table) indicies fall between token indicies.
+     *
+     *    col 0   --   token 0   --   col 1
+     */
+    this.table.splice(index + 1);
+    this.current = index;
+
+    // Incrementally keep track of results
+    this.results = this.finish();
 };
 
 Parser.prototype.finish = function() {

--- a/test/launch.js
+++ b/test/launch.js
@@ -143,4 +143,33 @@ describe("nearleyc", function() {
         parse(parentheses, '').should.deep.equal([]);
         parse(parentheses, '((((())))(())()').should.deep.equal([]);
     });
+
+});
+
+describe('Parser', function() {
+
+    var tosh = compile(read("examples/tosh.ne"));
+
+    it('can rewind', function() {
+        let first = "say 'hello'";
+        let second = " for 2 secs";
+        let p = new nearley.Parser(tosh, { keepHistory: true });
+        p.feed(first);
+        p.current.should.equal(11)
+        p.table.length.should.equal(12)
+
+        p.feed(second);
+
+        p.rewind(first.length);
+        p.current.should.equal(11)
+        p.table.length.should.equal(12)
+
+        p.results.should.deep.equal([['say:', 'hello']]);
+    });
+
+    it("won't rewind without `keepHistory` option", function() {
+        let p = new nearley.Parser(tosh, {});
+        p.rewind.should.throw();
+    })
+
 });


### PR DESCRIPTION
First off, we require calling finish() before reading `results`. This is a deliberate **API change**.
Currently, we "incrementally keep track of results". This means feeding the input in multiple chunks has a performance penalty.
I've patched our Stream implementation, so users of that API won't even notice this change!
Everyone else will have to drop in a `p.finish()` line before they read `p.results`.

Then, I added rewind(index), which requires the `keepHistory` option. It resets the parser state to the state after seeing that token. So if you feed it 10 tokens, rewind(10) has no effect. [rewind(11) is an error; you can't rewind forwards!]

Note that this is *not a reset* method. If you want to reset a parser, throw it away and initialise a new one. Assuming you're using `Grammar` directly this is basically free. If you're using an Earley parser, you shouldn't care about allocating one single object. :-)