### PR TITLE
Fix: Allow SystemJS to correctly infer module type

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,6 +1,4 @@
 (function(root, factory) {
-    // if (typeof define === 'function' && define.amd) {
-    //     define(['nearley'], factory);
     if (typeof module === 'object' && module.exports) {
         module.exports = factory(require('./nearley'));
     } else {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,6 +1,4 @@
 (function(root, factory) {
-    // if (typeof define === 'function' && define.amd) {
-    //     define(['nearley'], factory);
     if (typeof module === 'object' && module.exports) {
         module.exports = factory(require('./nearley'));
     } else {

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -1,6 +1,4 @@
 (function(root, factory) {
-    // if (typeof define === 'function' && define.amd) {
-    //     define([], factory);
     if (typeof module === 'object' && module.exports) {
         module.exports = factory();
     } else {


### PR DESCRIPTION
This PR resolves #196 
The comments I've removed were fooling SystemJS into thinking that nearley was an AMD module.