### PR TITLE
Make token matching semantics user-definable

### DIFF
--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -177,6 +177,12 @@ Grammar.fromCompiled = function(rules, start) {
 }
 
 
+function defaultMatcher(expect, token) {
+    // either regex or literal
+    return expect.test ? expect.test(token) : expect.literal === token
+}
+
+
 function Parser(rules, start, options) {
     if (rules instanceof Grammar) {
         var grammar = rules;
@@ -187,14 +193,10 @@ function Parser(rules, start, options) {
     this.grammar = grammar;
 
     // Read options
-    this.options = {
+    this.options = Object.assign({
         keepHistory: false,
-        // rewindable: false,
-    };
-    for (var key in (options || {})) {
-        this.options[key] = options[key];
-    }
-    // if (this.options.rewindable) { this.options.keepHistory = true; }
+        matcher: defaultMatcher,
+    }, options);
 
     // Setup a table
     var column = new Column(grammar, 0);
@@ -212,6 +214,7 @@ function Parser(rules, start, options) {
 Parser.fail = {};
 
 Parser.prototype.feed = function(chunk) {
+    var matcher = this.options.matcher;
     for (var chunkPos = 0; chunkPos < chunk.length; chunkPos++) {
         // We add new states to table[current+1]
         var column = this.table[this.current + chunkPos];
@@ -234,8 +237,7 @@ Parser.prototype.feed = function(chunk) {
             var state = scannable[w];
             var expect = state.rule.symbols[state.dot];
             // Try to consume the token
-            // either regex or literal
-            if (expect.test ? expect.test(token) : expect.literal === token) {
+            if (matcher(expect, token)) {
                 // Add it
                 var next = state.nextState(token);
                 nextColumn.states.push(next);

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -195,7 +195,7 @@ function Parser(rules, start, options) {
     // Read options
     this.options = Object.assign({
         keepHistory: false,
-        matcher: defaultMatcher,
+        match: defaultMatcher,
     }, options);
 
     // Setup a table
@@ -214,7 +214,7 @@ function Parser(rules, start, options) {
 Parser.fail = {};
 
 Parser.prototype.feed = function(chunk) {
-    var matcher = this.options.matcher;
+    var match = this.options.match;
     for (var chunkPos = 0; chunkPos < chunk.length; chunkPos++) {
         // We add new states to table[current+1]
         var column = this.table[this.current + chunkPos];
@@ -237,7 +237,7 @@ Parser.prototype.feed = function(chunk) {
             var state = scannable[w];
             var expect = state.rule.symbols[state.dot];
             // Try to consume the token
-            if (matcher(expect, token)) {
+            if (match(expect, token)) {
                 // Add it
                 var next = state.nextState(token);
                 nextColumn.states.push(next);


### PR DESCRIPTION
As per our conversation @hardmath123.

This makes the custom tokens feature a little more useful; you can still define your own tokens with the %-syntax just as before, but now you have complete control over how symbols get matched with tokens inside the parser.

I couldn't detect any performance difference using our benchmarks.