### PR TITLE
Adds option to pass token end locations

### DIFF
--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -30,12 +30,13 @@ Rule.prototype.toString = function(withCursorAt) {
 
 
 // a State is a rule at a position from a given starting point in the input stream (reference)
-function State(rule, dot, reference, wantedBy) {
+function State(rule, dot, reference, wantedBy, options) {
     this.rule = rule;
     this.dot = dot;
     this.reference = reference;
     this.data = [];
     this.wantedBy = wantedBy;
+    this.options = options;
     this.isComplete = this.dot === rule.symbols.length;
 }
 
@@ -44,7 +45,7 @@ State.prototype.toString = function() {
 };
 
 State.prototype.nextState = function(data) {
-    var state = new State(this.rule, this.dot + 1, this.reference, this.wantedBy);
+    var state = new State(this.rule, this.dot + 1, this.reference, this.wantedBy, this.options);
     state.left = this;
     state.right = data;
     if (state.isComplete) {
@@ -64,16 +65,22 @@ State.prototype.build = function() {
     return children;
 };
 
-State.prototype.finish = function() {
+State.prototype.finish = function(pos) {
     if (this.rule.postprocess) {
-        this.data = this.rule.postprocess(this.data, this.reference, Parser.fail);
+        if (this.options.fullLocation) {
+            this.data = this.rule.postprocess(this.data, [this.reference, pos + 1], Parser.fail);
+        }
+        else {
+            this.data = this.rule.postprocess(this.data, this.reference, Parser.fail);
+        }
     }
 };
 
 
-function Column(grammar, index) {
+function Column(grammar, index, options) {
     this.grammar = grammar;
     this.index = index;
+    this.options = options;
     this.states = [];
     this.wants = {}; // states indexed by the non-terminal they expect
     this.scannable = []; // list of states that expect a token
@@ -81,7 +88,7 @@ function Column(grammar, index) {
 }
 
 
-Column.prototype.process = function(nextColumn) {
+Column.prototype.process = function(pos) {
     var states = this.states;
     var wants = this.wants;
     var completed = this.completed;
@@ -90,7 +97,7 @@ Column.prototype.process = function(nextColumn) {
         var state = states[w];
 
         if (state.isComplete) {
-            state.finish();
+            state.finish(pos);
             if (state.data !== Parser.fail) {
                 // complete
                 var wantedBy = state.wantedBy;
@@ -140,7 +147,7 @@ Column.prototype.predict = function(exp) {
     for (var i = 0; i < rules.length; i++) {
         var r = rules[i];
         var wantedBy = this.wants[exp];
-        var s = new State(r, 0, this.index, wantedBy);
+        var s = new State(r, 0, this.index, wantedBy, this.options);
         this.states.push(s);
     }
 }
@@ -189,6 +196,7 @@ function Parser(rules, start, options) {
     // Read options
     this.options = {
         keepHistory: false,
+        fullLocation: false
         // rewindable: false,
     };
     for (var key in (options || {})) {
@@ -197,14 +205,14 @@ function Parser(rules, start, options) {
     // if (this.options.rewindable) { this.options.keepHistory = true; }
 
     // Setup a table
-    var column = new Column(grammar, 0);
+    var column = new Column(grammar, 0, this.options);
     var table = this.table = [column];
 
     // I could be expecting anything.
     column.wants[grammar.start] = [];
     column.predict(grammar.start);
     // TODO what if start rule is nullable?
-    column.process();
+    column.process(0);
     this.current = 0;
 }
 
@@ -222,7 +230,7 @@ Parser.prototype.feed = function(chunk) {
         }
 
         var n = this.current + chunkPos + 1;
-        var nextColumn = new Column(this.grammar, n);
+        var nextColumn = new Column(this.grammar, n, this.options);
         this.table.push(nextColumn);
 
         // Advance all tokens that expect the symbol
@@ -250,7 +258,7 @@ Parser.prototype.feed = function(chunk) {
         // To prevent duplication, we also keep track of rules we have already
         // added
 
-        nextColumn.process();
+        nextColumn.process(chunkPos);
 
         // If needed, throw an error:
         if (nextColumn.states.length === 0) {


### PR DESCRIPTION
Hi there,

I've been working on an expression parsing language with syntax highlighting and thus found a need for the end locations for each rule application to be passed to the postprocessor functions.  Not sure if there's a better alternative here, but it seemed sensible to thread the parser options reference down to the Column and State objects for future configuration flexibility.

Not sure if this is the best approach, as I've just started familiarizing myself with this project yesterday, so please let me know if there is a preferable alternative way to achieve this.