### PR TITLE
better error in .feed method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ test/whitespace.js
 npm-debug.log
 tmp.*
 sandbox/
-yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test/whitespace.js
 npm-debug.log
 tmp.*
 sandbox/
+yarn.lock

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -101,7 +101,7 @@ Column.prototype.process = function(nextColumn) {
 
                 // special-case nullables
                 if (state.reference === this.index) {
-                    // make sure future predictors of this rule get completed.
+                    // make sure future predictors of this rule get completed. 
                     var exp = state.rule.name;
                     (this.completed[exp] = this.completed[exp] || []).push(state);
                 }
@@ -250,29 +250,14 @@ Parser.prototype.feed = function(chunk) {
         // To prevent duplication, we also keep track of rules we have already
         // added
 
-
         nextColumn.process();
 
         // If needed, throw an error:
         if (nextColumn.states.length === 0) {
             // No states at all! This is not good.
-            var lines = chunk.split('\n');
-            var pos = this.current + chunkPos;
-            var lineNum = lines.length;
-            var colNum = pos;
-            for (var i = 0; i < lines.length; i++) {
-                var line = lines[i];
-                if (pos <= line.length){
-                    lineNum = i + 1;
-                    colNum = pos + 1;
-                    break;
-                }else{
-                    pos -= (line.length + 1);
-                }
-            }
             var err = new Error(
-                "[nearley feed] No possible parsings for\n `" + chunk[chunkPos] + "` @"+lineNum+":" + (colNum)
-                    + "\n"+lines[lineNum - 1]+"\n"
+                "nearley: No possible parsings (@" + (this.current + chunkPos)
+                    + ": '" + chunk[chunkPos] + "')."
             );
             err.offset = this.current + chunkPos;
             throw err;

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -101,7 +101,7 @@ Column.prototype.process = function(nextColumn) {
 
                 // special-case nullables
                 if (state.reference === this.index) {
-                    // make sure future predictors of this rule get completed. 
+                    // make sure future predictors of this rule get completed.
                     var exp = state.rule.name;
                     (this.completed[exp] = this.completed[exp] || []).push(state);
                 }
@@ -250,14 +250,29 @@ Parser.prototype.feed = function(chunk) {
         // To prevent duplication, we also keep track of rules we have already
         // added
 
+
         nextColumn.process();
 
         // If needed, throw an error:
         if (nextColumn.states.length === 0) {
             // No states at all! This is not good.
+            var lines = chunk.split('\n');
+            var pos = this.current + chunkPos;
+            var lineNum = lines.length;
+            var colNum = pos;
+            for (var i = 0; i < lines.length; i++) {
+                var line = lines[i];
+                if (pos <= line.length){
+                    lineNum = i + 1;
+                    colNum = pos + 1;
+                    break;
+                }else{
+                    pos -= (line.length + 1);
+                }
+            }
             var err = new Error(
-                "nearley: No possible parsings (@" + (this.current + chunkPos)
-                    + ": '" + chunk[chunkPos] + "')."
+                "[nearley feed] No possible parsings for\n `" + chunk[chunkPos] + "` @"+lineNum+":" + (colNum)
+                    + "\n"+lines[lineNum - 1]+"\n"
             );
             err.offset = this.current + chunkPos;
             throw err;


### PR DESCRIPTION
When a "No possible parsings" error is thrown, now it shows the line
number and column number where the character in question is (instead of
its position in the whole chunk), as well as the content of that line.

Also changed the wording a bit.

Note: As to Line 104, the tailing whitespace was automatically deleted
by my code editor...