### PR TITLE
Bugfix/ts preprocessor exports

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -188,6 +188,7 @@
     generate.typescript.builtinPostprocessors = {
         "joiner": "(d) => d.join('')",
         "arrconcat": "(d) => [d[0]].concat(d[1])",
+        "arrpush": "(d) -> d[0].concat([d[1]])",
         "nuller": "() => null",
         "id": "id"
     };

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -184,7 +184,7 @@ generate.ts = generate.typescript = function (parser, exportName) {
 generate.typescript.builtinPostprocessors = {
     "joiner": "(d) => d.join('')",
     "arrconcat": "(d) => [d[0]].concat(d[1])",
-    "nuller": "(d) => null",
+    "nuller": "() => null",
     "id": "id"
 };
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,194 +1,198 @@
-(function(root, factory) {
+(function (root, factory) {
     if (typeof module === 'object' && module.exports) {
         module.exports = factory(require('./nearley'));
     } else {
         root.generate = factory(root.nearley);
     }
-}(this, function(nearley) {
+}(this, function (nearley) {
 
-function serializeRules(rules, builtinPostprocessors) {
-    return "[\n    " + rules.map(function(rule) {
-      return serializeRule(rule, builtinPostprocessors);
-    }).join(",\n    ") + "\n]";
-}
-
-function dedentFunc(func) {
-    var lines = func.toString().split(/\n/);
-
-    if (lines.length === 1) {
-        return [lines[0].replace(/^\s+|\s+$/g, '')];
+    function serializeRules(rules, builtinPostprocessors) {
+        return "[\n    " + rules.map(function (rule) {
+            return serializeRule(rule, builtinPostprocessors);
+        }).join(",\n    ") + "\n]";
     }
 
-    var indent = null;
-    var tail = lines.slice(1);
-    for (var i = 0; i < tail.length; i++) {
-        var match = /^\s*/.exec(tail[i]);
-        if (match && match[0].length !== tail[i].length) {
-            if (indent === null ||
-                match[0].length < indent.length) {
-                indent = match[0];
+    function dedentFunc(func) {
+        var lines = func.toString().split(/\n/);
+
+        if (lines.length === 1) {
+            return [lines[0].replace(/^\s+|\s+$/g, '')];
+        }
+
+        var indent = null;
+        var tail = lines.slice(1);
+        for (var i = 0; i < tail.length; i++) {
+            var match = /^\s*/.exec(tail[i]);
+            if (match && match[0].length !== tail[i].length) {
+                if (indent === null ||
+                    match[0].length < indent.length) {
+                    indent = match[0];
+                }
             }
         }
-    }
 
-    if (indent === null) {
-        return lines;
-    }
-
-    return lines.map(function dedent(line) {
-        if (line.slice(0, indent.length) === indent) {
-            return line.slice(indent.length);
-        }
-        return line;
-    });
-}
-
-function tabulateString(string, indent, options) {
-    var lines;
-    if(Array.isArray(string)) {
-      lines = string;
-    } else {
-      lines = string.toString().split('\n');
-    }
-
-    options = options || {};
-    tabulated = lines.map(function addIndent(line, i) {
-        var shouldIndent = true;
-
-        if(i == 0 && !options.indentFirst) {
-          shouldIndent = false;
+        if (indent === null) {
+            return lines;
         }
 
-        if(shouldIndent) {
-            return indent + line;
-        } else {
+        return lines.map(function dedent(line) {
+            if (line.slice(0, indent.length) === indent) {
+                return line.slice(indent.length);
+            }
             return line;
+        });
+    }
+
+    function tabulateString(string, indent, options) {
+        var lines;
+        if (Array.isArray(string)) {
+            lines = string;
+        } else {
+            lines = string.toString().split('\n');
         }
-    }).join('\n');
 
-    return tabulated;
-}
+        options = options || {};
+        tabulated = lines.map(function addIndent(line, i) {
+            var shouldIndent = true;
 
-function serializeSymbol(s) {
-    if (s instanceof RegExp) {
-        return s.toString();
-    } else if (s.token) {
-        return s.token;
-    } else {
-        return JSON.stringify(s);
+            if (i == 0 && !options.indentFirst) {
+                shouldIndent = false;
+            }
+
+            if (shouldIndent) {
+                return indent + line;
+            } else {
+                return line;
+            }
+        }).join('\n');
+
+        return tabulated;
     }
-}
 
-function serializeRule(rule, builtinPostprocessors) {
-    var ret = '{';
-    ret += '"name": ' + JSON.stringify(rule.name);
-    ret += ', "symbols": [' + rule.symbols.map(serializeSymbol).join(', ') + ']';
-    if (rule.postprocess) {
-        if(rule.postprocess.builtin) {
-            rule.postprocess = builtinPostprocessors[rule.postprocess.builtin];
+    function serializeSymbol(s) {
+        if (s instanceof RegExp) {
+            return s.toString();
+        } else if (s.token) {
+            return s.token;
+        } else {
+            return JSON.stringify(s);
         }
-        ret += ', "postprocess": ' + tabulateString(dedentFunc(rule.postprocess), '        ', {indentFirst: false});
-    }
-    ret += '}';
-    return ret;
-}
-
-var generate = function (parser, exportName) {
-    if(!parser.config.preprocessor) {
-        parser.config.preprocessor = "_default";
     }
 
-    if(!generate[parser.config.preprocessor]) {
-        throw new Error("No such preprocessor: " + parser.config.preprocessor)
+    function serializeRule(rule, builtinPostprocessors) {
+        var ret = '{';
+        ret += '"name": ' + JSON.stringify(rule.name);
+        ret += ', "symbols": [' + rule.symbols.map(serializeSymbol).join(', ') + ']';
+        if (rule.postprocess) {
+            if (rule.postprocess.builtin) {
+                rule.postprocess = builtinPostprocessors[rule.postprocess.builtin];
+            }
+            ret += ', "postprocess": ' + tabulateString(dedentFunc(rule.postprocess), '        ', { indentFirst: false });
+        }
+        ret += '}';
+        return ret;
     }
 
-    return generate[parser.config.preprocessor](parser, exportName);
-};
+    var generate = function (parser, exportName) {
+        if (!parser.config.preprocessor) {
+            parser.config.preprocessor = "_default";
+        }
 
-generate.js = generate._default = generate.javascript = function (parser, exportName) {
-    var output = "// Generated automatically by nearley\n";
-    output +=  "// http://github.com/Hardmath123/nearley\n";
-    output += "(function () {\n";
-    output += "function id(x) {return x[0]; }\n";
-    output += parser.body.join('\n');
-    output += "var grammar = {\n";
-    output += "    Lexer: " + parser.config.lexer + ",\n";
-    output += "    ParserRules: " +
-        serializeRules(parser.rules, generate.javascript.builtinPostprocessors)
-        + "\n";
-    output += "  , ParserStart: " + JSON.stringify(parser.start) + "\n";
-    output += "}\n";
-    output += "if (typeof module !== 'undefined'"
-        + "&& typeof module.exports !== 'undefined') {\n";
-    output += "   module.exports = grammar;\n";
-    output += "} else {\n";
-    output += "   window." + exportName + " = grammar;\n";
-    output += "}\n";
-    output += "})();\n";
-    return output;
-};
-generate.javascript.builtinPostprocessors = {
-    "joiner": "function joiner(d) {return d.join('');}",
-    "arrconcat": "function arrconcat(d) {return [d[0]].concat(d[1]);}",
-    "arrpush": "function arrpush(d) {return d[0].concat([d[1]]);}",
-    "nuller": "function(d) {return null;}",
-    "id": "id"
-}
+        if (!generate[parser.config.preprocessor]) {
+            throw new Error("No such preprocessor: " + parser.config.preprocessor)
+        }
 
-generate.cs = generate.coffee = generate.coffeescript = function (parser, exportName) {
-    var output = "# Generated automatically by nearley\n";
-    output +=  "# http://github.com/Hardmath123/nearley\n";
-    output += "do ->\n";
-    output += "  id = (d)->d[0]\n";
-    output += tabulateString(dedentFunc(parser.body.join('\n')), '  ') + '\n';
-    output += "  grammar = {\n";
-    output += "    Lexer: " + parser.config.lexer + ",\n";
-    output += "    ParserRules: " +
-        tabulateString(
+        return generate[parser.config.preprocessor](parser, exportName);
+    };
+
+    generate.js = generate._default = generate.javascript = function (parser, exportName) {
+        var output = "// Generated automatically by nearley\n";
+        output += "// http://github.com/Hardmath123/nearley\n";
+        output += "(function () {\n";
+        output += "function id(x) {return x[0]; }\n";
+        output += parser.body.join('\n');
+        output += "var grammar = {\n";
+        output += "    Lexer: " + parser.config.lexer + ",\n";
+        output += "    ParserRules: " +
+            serializeRules(parser.rules, generate.javascript.builtinPostprocessors)
+            + "\n";
+        output += "  , ParserStart: " + JSON.stringify(parser.start) + "\n";
+        output += "}\n";
+        output += "if (typeof module !== 'undefined'"
+            + "&& typeof module.exports !== 'undefined') {\n";
+        output += "   module.exports = grammar;\n";
+        output += "} else {\n";
+        output += "   window." + exportName + " = grammar;\n";
+        output += "}\n";
+        output += "})();\n";
+        return output;
+    };
+    generate.javascript.builtinPostprocessors = {
+        "joiner": "function joiner(d) {return d.join('');}",
+        "arrconcat": "function arrconcat(d) {return [d[0]].concat(d[1]);}",
+        "arrpush": "function arrpush(d) {return d[0].concat([d[1]]);}",
+        "nuller": "function(d) {return null;}",
+        "id": "id"
+    }
+
+    generate.cs = generate.coffee = generate.coffeescript = function (parser, exportName) {
+        var output = "# Generated automatically by nearley\n";
+        output += "# http://github.com/Hardmath123/nearley\n";
+        output += "do ->\n";
+        output += "  id = (d)->d[0]\n";
+        output += tabulateString(dedentFunc(parser.body.join('\n')), '  ') + '\n';
+        output += "  grammar = {\n";
+        output += "    Lexer: " + parser.config.lexer + ",\n";
+        output += "    ParserRules: " +
+            tabulateString(
                 serializeRules(parser.rules, generate.coffeescript.builtinPostprocessors),
                 '      ',
-                {indentFirst: false})
-    + ",\n";
-    output += "    ParserStart: " + JSON.stringify(parser.start) + "\n";
-    output += "  }\n";
-    output += "  if typeof module != 'undefined' "
-        + "&& typeof module.exports != 'undefined'\n";
-    output += "    module.exports = grammar;\n";
-    output += "  else\n";
-    output += "    window." + exportName + " = grammar;\n";
-    return output;
-};
-generate.coffeescript.builtinPostprocessors = {
-    "joiner": "(d) -> d.join('')",
-    "arrconcat": "(d) -> [d[0]].concat(d[1])",
-    "arrpush": "(d) -> d[0].concat([d[1]])",
-    "nuller": "() -> null",
-    "id": "id"
-};
-
-generate.ts = generate.typescript = function (parser, exportName) {
-    var output = "// Generated automatically by nearley\n";
-    output +=  "// http://github.com/Hardmath123/nearley\n";
-    output += "function id(d:any[]):any {return d[0];}\n";
-    output += parser.body.join('\n');
-    output += "export interface NearleyGrammar {ParserRules:NearleyRule[]; ParserStart:string, Lexer?:any};\n";
-    output += "export interface NearleyRule {name:string; symbols:NearleySymbol[]; postprocess?:(d:any[],loc?:number,reject?:{})=>any};\n";
-    output += "export type NearleySymbol = string | {literal:any} | {test:(token:any) => boolean};\n";
-    output += "export var grammar : NearleyGrammar = {\n";
-    output += "    Lexer: " + parser.config.lexer + ",\n";
-    output += "    ParserRules: " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors) + "\n";
-    output += "  , ParserStart: " + JSON.stringify(parser.start) + "\n";
-    output += "}\n";
-    return output;
-};
-generate.typescript.builtinPostprocessors = {
-    "joiner": "(d) => d.join('')",
-    "arrconcat": "(d) => [d[0]].concat(d[1])",
-    "nuller": "() => null",
-    "id": "id"
-};
+                { indentFirst: false })
+            + ",\n";
+        output += "    ParserStart: " + JSON.stringify(parser.start) + "\n";
+        output += "  }\n";
+        output += "  if typeof module != 'undefined' "
+            + "&& typeof module.exports != 'undefined'\n";
+        output += "    module.exports = grammar;\n";
+        output += "  else\n";
+        output += "    window." + exportName + " = grammar;\n";
+        return output;
+    };
+    generate.coffeescript.builtinPostprocessors = {
+        "joiner": "(d) -> d.join('')",
+        "arrconcat": "(d) -> [d[0]].concat(d[1])",
+        "arrpush": "(d) -> d[0].concat([d[1]])",
+        "nuller": "() -> null",
+        "id": "id"
+    };
 
 
-return generate;
+    generate.ts = generate.typescript = function (parser, exportName) {
+        var output = "// Generated automatically by nearley\n";
+        output += "// http://github.com/Hardmath123/nearley\n";
+        output += "function id(d:any[]):any {return d[0];}\n";
+        output += parser.body.join('\n');
+        output += "export type Info = any;\n";
+        output += "export interface Token { value: any, [key: string]: any };\n";
+        output += "export interface Lexer { reset: (chunk: string, info: Info) => void, next: () => Token, save: () => Info, formatError: (token: Token) => string, has: (tokenType: string) => boolean };\n";
+        output += "export interface NearleyGrammar {ParserRules:NearleyRule[]; ParserStart:string, Lexer:Lexer|undefined};\n";
+        output += "export interface NearleyRule {name:string; symbols:NearleySymbol[]; postprocess?:(d:any[],loc?:number,reject?:{})=>any};\n";
+        output += "export type NearleySymbol = string | {literal:any} | {test:(token:any) => boolean};\n";
+        output += "export var grammar : NearleyGrammar = {\n";
+        output += "    Lexer: " + parser.config.lexer + ",\n";
+        output += "    ParserRules: " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors) + "\n";
+        output += "  , ParserStart: " + JSON.stringify(parser.start) + "\n";
+        output += "}\n";
+        return output;
+    };
+    generate.typescript.builtinPostprocessors = {
+        "joiner": "(d) => d.join('')",
+        "arrconcat": "(d) => [d[0]].concat(d[1])",
+        "nuller": "() => null",
+        "id": "id"
+    };
+
+
+    return generate;
 
 }));

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -171,9 +171,9 @@ generate.ts = generate.typescript = function (parser, exportName) {
     output +=  "// http://github.com/Hardmath123/nearley\n";
     output += "function id(d:any[]):any {return d[0];}\n";
     output += parser.body.join('\n');
-    output += "interface NearleyGrammar {ParserRules:NearleyRule[]; ParserStart:string};\n";
-    output += "interface NearleyRule {name:string; symbols:NearleySymbol[]; postprocess?:(d:any[],loc?:number,reject?:{})=>any};\n";
-    output += "type NearleySymbol = string | {literal:any} | {test:(token:any) => boolean};\n";
+    output += "export interface NearleyGrammar {ParserRules:NearleyRule[]; ParserStart:string};\n";
+    output += "export interface NearleyRule {name:string; symbols:NearleySymbol[]; postprocess?:(d:any[],loc?:number,reject?:{})=>any};\n";
+    output += "export type NearleySymbol = string | {literal:any} | {test:(token:any) => boolean};\n";
     output += "export var grammar : NearleyGrammar = {\n";
     output += "    Lexer: " + parser.config.lexer + ",\n";
     output += "    ParserRules: " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors) + "\n";

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -171,7 +171,7 @@ generate.ts = generate.typescript = function (parser, exportName) {
     output +=  "// http://github.com/Hardmath123/nearley\n";
     output += "function id(d:any[]):any {return d[0];}\n";
     output += parser.body.join('\n');
-    output += "export interface NearleyGrammar {ParserRules:NearleyRule[]; ParserStart:string};\n";
+    output += "export interface NearleyGrammar {ParserRules:NearleyRule[]; ParserStart:string, Lexer?:any};\n";
     output += "export interface NearleyRule {name:string; symbols:NearleySymbol[]; postprocess?:(d:any[],loc?:number,reject?:{})=>any};\n";
     output += "export type NearleySymbol = string | {literal:any} | {test:(token:any) => boolean};\n";
     output += "export var grammar : NearleyGrammar = {\n";


### PR DESCRIPTION
My first fix was just about the typing of the datastructures and didn't fix the #223.
But I managed to fix it, there was missing the arrpush template in generate.typescript.builtinPostprocessors (generator.js)

# Test/Benchmark results before changes:
```
$ npm test

> nearley@2.9.2 test /home/XXX/Development/Private/Web/nearley
> mocha test/launch.js



  nearleyc
    ✓ should build test parser (check integrity) (130ms)
    ✓ should build for CoffeeScript (308ms)
    ✓ calculator example (44ms)
    ✓ csscolor example (60ms)
    ✓ exponential whitespace bug
    ✓ nullable whitespace bug
    ✓ percent bug
    ✓ tokens
    ✓ leo bug
    ✓ json example compiles
    ✓ json test1
    ✓ json test2
    ✓ tosh example (390ms)
    ✓ classic crontab (83ms)
    ✓ parentheses

  Parser
    ✓ shows line number in errors
    ✓ shows token index in errors
    ✓ can save state
    ✓ can rewind
    ✓ won't rewind without `keepHistory` option
    ✓ restores line numbers
    ✓ restores column number


  22 passing (1s)

$ npm run benchmark

> nearley@2.9.2 benchmark /home/XXX/Development/Private/Web/nearley
> node test/benchmark.js

  ✔ calculator arithmetic2 x 2,732 ops/sec ±1.09% (86 runs sampled)
  ✔ json sample1k.json x 34.97 ops/sec ±4.42% (47 runs sampled)
  ✔ tosh ex1 x 520 ops/sec ±1.49% (84 runs sampled)
```
# Test/Benchmark results after changes:
```
$ npm test

> nearley@2.9.2 test /home/XXX/Development/Private/Web/nearley
> mocha test/launch.js



  nearleyc
    ✓ should build test parser (check integrity) (130ms)
    ✓ should build for CoffeeScript (297ms)
    ✓ calculator example (45ms)
    ✓ csscolor example (57ms)
    ✓ exponential whitespace bug
    ✓ nullable whitespace bug
    ✓ percent bug
    ✓ tokens
    ✓ leo bug
    ✓ json example compiles
    ✓ json test1
    ✓ json test2
    ✓ tosh example (378ms)
    ✓ classic crontab (72ms)
    ✓ parentheses

  Parser
    ✓ shows line number in errors
    ✓ shows token index in errors
    ✓ can save state
    ✓ can rewind
    ✓ won't rewind without `keepHistory` option
    ✓ restores line numbers
    ✓ restores column number


  22 passing (1s)

$ npm run benchmark

> nearley@2.9.2 benchmark /home/XXX/Development/Private/Web/nearley
> node test/benchmark.js

  ✔ calculator arithmetic2 x 2,817 ops/sec ±0.38% (88 runs sampled)
  ✔ json sample1k.json x 37.49 ops/sec ±4.40% (51 runs sampled)
  ✔ tosh ex1 x 509 ops/sec ±1.66% (83 runs sampled)```