### PR TITLE
Fixed sstrchar definition

### DIFF
--- a/builtin/string.ne
+++ b/builtin/string.ne
@@ -12,7 +12,7 @@ dstrchar -> [^\\"\n] {% id %}
     }
 %}
 
-sstrchar -> [^\\\n] {% id %}
+sstrchar -> [^\\'\n] {% id %}
     | "\\" strescape
         {% function(d) { return JSON.parse("\""+d.join("")+"\""); } %}
     | "\\'"


### PR DESCRIPTION
Original did not properly matching code like `'foo''bar'`.