### PR TITLE
Fix TypeScript postprocessor: improve and export types

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -15,6 +15,7 @@ function Compile(structure, opts) {
     var result = {
         rules: [],
         body: [], // @directives list
+        customTokens: [], // %tokens
         config: {}, // @config value
         macros: {},
         start: ''
@@ -52,6 +53,7 @@ function Compile(structure, opts) {
                 require('./lint.js')(c, {out: process.stderr});
                 result.rules = result.rules.concat(c.rules);
                 result.body  = result.body.concat(c.body);
+                result.customTokens = result.customTokens.concat(c.customTokens);
                 Object.keys(c.config).forEach(function(k) {
                     result.config[k] = c.config[k];
                 });
@@ -126,6 +128,9 @@ function Compile(structure, opts) {
         if (token.token) {
             if (result.config.lexer) {
                 var name = token.token;
+                if (result.customTokens.indexOf(name) === -1) {
+                    result.customTokens.push(name);
+                }
                 var expr = result.config.lexer + ".has(" + JSON.stringify(name) + ") ? {type: " + JSON.stringify(name) + "} : " + name;
                 return {token: "(" + expr + ")"};
             }

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -173,7 +173,7 @@ generate.ts = generate.typescript = function (parser, exportName) {
     output += parser.customTokens.map(function (token) { return "declare var " + token + ":any;\n" }).join("")
     output += parser.body.join('\n');
     output += "export interface Token {value:any; [key: string]:any};\n";
-    output += "export interface Lexer {reset:(chunk:string, info:any) => void; next:() => Token; save:() => any; formatError:(token:Token) => string; has:(tokenType:string) => boolean};\n";
+    output += "export interface Lexer {reset:(chunk:string, info:any) => void; next:() => Token | undefined; save:() => any; formatError:(token:Token) => string; has:(tokenType:string) => boolean};\n";
     output += "export interface NearleyRule {name:string; symbols:NearleySymbol[]; postprocess?:(d:any[],loc?:number,reject?:{})=>any};\n";
     output += "export type NearleySymbol = string | {literal:any} | {test:(token:any) => boolean};\n";
     output += "export var Lexer:Lexer|undefined = " + parser.config.lexer + ";\n";

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -173,14 +173,11 @@ generate.ts = generate.typescript = function (parser, exportName) {
     output += parser.body.join('\n');
     output += "export interface Token {value:any; [key: string]:any};\n";
     output += "export interface Lexer {reset:(chunk:string, info:any) => void; next:() => Token; save:() => any; formatError:(token:Token) => string; has:(tokenType:string) => boolean};\n";
-    output += "export interface NearleyGrammar {ParserRules:NearleyRule[]; ParserStart:string; Lexer:Lexer|undefined};\n";
     output += "export interface NearleyRule {name:string; symbols:NearleySymbol[]; postprocess?:(d:any[],loc?:number,reject?:{})=>any};\n";
     output += "export type NearleySymbol = string | {literal:any} | {test:(token:any) => boolean};\n";
-    output += "export var grammar : NearleyGrammar = {\n";
-    output += "    Lexer: " + parser.config.lexer + ",\n";
-    output += "    ParserRules: " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors) + "\n";
-    output += "  , ParserStart: " + JSON.stringify(parser.start) + "\n";
-    output += "}\n";
+    output += "export var Lexer:Lexer|undefined = " + parser.config.lexer + ";\n";
+    output += "export var ParserRules:NearleyRule[] = " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors) + ";\n";
+    output += "export var ParserStart:string = " + JSON.stringify(parser.start) + ";\n";
     return output;
 };
 generate.typescript.builtinPostprocessors = {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -171,9 +171,11 @@ generate.ts = generate.typescript = function (parser, exportName) {
     output +=  "// http://github.com/Hardmath123/nearley\n";
     output += "function id(d:any[]):any {return d[0];}\n";
     output += parser.body.join('\n');
-    output += "interface NearleyGrammar {ParserRules:NearleyRule[]; ParserStart:string};\n";
-    output += "interface NearleyRule {name:string; symbols:NearleySymbol[]; postprocess?:(d:any[],loc?:number,reject?:{})=>any};\n";
-    output += "type NearleySymbol = string | {literal:any} | {test:(token:any) => boolean};\n";
+    output += "export interface Token {value:any; [key: string]:any};\n";
+    output += "export interface Lexer {reset:(chunk:string, info:any) => void; next:() => Token; save:() => any; formatError:(token:Token) => string; has:(tokenType:string) => boolean};\n";
+    output += "export interface NearleyGrammar {ParserRules:NearleyRule[]; ParserStart:string; Lexer:Lexer|undefined};\n";
+    output += "export interface NearleyRule {name:string; symbols:NearleySymbol[]; postprocess?:(d:any[],loc?:number,reject?:{})=>any};\n";
+    output += "export type NearleySymbol = string | {literal:any} | {test:(token:any) => boolean};\n";
     output += "export var grammar : NearleyGrammar = {\n";
     output += "    Lexer: " + parser.config.lexer + ",\n";
     output += "    ParserRules: " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors) + "\n";
@@ -184,7 +186,8 @@ generate.ts = generate.typescript = function (parser, exportName) {
 generate.typescript.builtinPostprocessors = {
     "joiner": "(d) => d.join('')",
     "arrconcat": "(d) => [d[0]].concat(d[1])",
-    "nuller": "(d) => null",
+    "arrpush": "(d) => d[0].concat([d[1]])",
+    "nuller": "() => null",
     "id": "id"
 };
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -170,6 +170,7 @@ generate.ts = generate.typescript = function (parser, exportName) {
     var output = "// Generated automatically by nearley\n";
     output +=  "// http://github.com/Hardmath123/nearley\n";
     output += "function id(d:any[]):any {return d[0];}\n";
+    output += parser.customTokens.map(function (token) { return "declare var " + token + ":any;\n" }).join("")
     output += parser.body.join('\n');
     output += "export interface Token {value:any; [key: string]:any};\n";
     output += "export interface Lexer {reset:(chunk:string, info:any) => void; next:() => Token; save:() => any; formatError:(token:Token) => string; has:(tokenType:string) => boolean};\n";

--- a/package.json
+++ b/package.json
@@ -36,11 +36,14 @@
     "url": "https://github.com/hardmath123/nearley.git"
   },
   "devDependencies": {
+    "@types/moo": "^0.3.0",
+    "@types/node": "^7.0.27",
     "benchmark": "^2.1.3",
     "chai": "^3.4.1",
     "coffee-script": "^1.10.0",
     "microtime": "^2.1.2",
     "mocha": "^2.3.4",
-    "moo": "^0.3.2"
+    "moo": "^0.3.2",
+    "typescript": "^2.3.4"
   }
 }

--- a/test/launch.js
+++ b/test/launch.js
@@ -43,6 +43,14 @@ describe("nearleyc", function() {
             .should.deep.equal([ [ 'ABCDEFZ', '12309' ] ]);
     });
 
+    it('should build for TypeScript', function() {
+        externalNearleyc("test/typescript-test.ne -o test/tmp.typescript-test.ts").should.equal("");
+        sh("node ./node_modules/typescript/bin/tsc --project test");
+        var grammar = evalGrammar(read("test/tmp.typescript-test.js"));
+        parse(grammar, "<123>")
+            .should.deep.equal([ [ '<', '123', '>' ] ]);
+    });
+
     it('calculator example', function() {
         var arith = compile(read("examples/calculator/arithmetic.ne"));
         parse(arith, "ln (3 + 2*(8/e - sin(pi/5)))")

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "strict": true
+  },
+  "include": [
+    "./tmp.typescript-test.ts"
+  ]
+}

--- a/test/typescript-test.ne
+++ b/test/typescript-test.ne
@@ -1,0 +1,15 @@
+@preprocessor typescript
+
+@{%
+import { compile } from 'moo'
+
+const lexer = compile({
+  larrow: '<',
+  rarrow: '>',
+  integer: /[0-9]+/
+});
+%}
+
+@lexer lexer
+
+expression -> %larrow %integer %rarrow {% parts => parts.map(p => p.value) %}


### PR DESCRIPTION
Mega-PR with all the fixes for TypeScript.

- Improve and export interfaces from the generated TS. Closes #233, #234.
- Add `arrpush` built-in postprocessor as in other generators. Closes #223.
- Declare custom tokens in the generated TS to avoid errors when compiling to JS. Closes #241.

The first commit (055d79bc213102173118f67b1078c0f032066c21) is a squashed and consistently formatted version of #234. I double-checked, it's equivalent to that PR, nothing was lost. That PR looks larger because of the formatting changes.