### PR TITLE
Strict mode compatibility fix

### DIFF
--- a/how-to-grammar-good.md
+++ b/how-to-grammar-good.md
@@ -83,7 +83,7 @@ issue.
 
 ### Don't shy away from left recursion
 
-You were a good little student and you payed attention to your professors when
+You were a good little student and you paid attention to your professors when
 they told you never to write grammars like:
 
     a -> a "something"

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -269,6 +269,7 @@ Parser.prototype.feed = function(chunk) {
     var lexer = this.lexer;
     lexer.reset(chunk, this.lexerState);
 
+    var token;
     while (token = lexer.next()) {
         // We add new states to table[current+1]
         var column = this.table[this.current];


### PR DESCRIPTION
I pulled [the awesome!] Nearley into a personal project via Browserify and found that when Browserify added 'use strict', Nearley crashed in a `where` clause. This change fixes it (and I tweaked the docs as well. :) )