### PR TITLE
Adds link to nearley-gulp in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,10 @@ Webpack users can use
 [nearley-loader](https://github.com/kozily/nearley-loader) by Andrés Arana to
 load grammars directly.
 
+Gulp users can use
+[gulp-nearley](https://github.com/JosephJNK/gulp-nearley) by Joseph Junker to
+compile grammars with a gulpfile.
+
 
 Still confused?
 ---------------


### PR DESCRIPTION
I wrote a small gulp plugin wrapper around the existing `nearly-loader` plugin, and thought it might be useful to others as well. I tried to match the format of the other tooling links in the README.