### PR TITLE
Refactor benchmarks using benchr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,12 @@
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
     "aproba": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
@@ -67,6 +73,18 @@
       "requires": {
         "lodash": "4.17.4",
         "platform": "1.3.4"
+      }
+    },
+    "benchr": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/benchr/-/benchr-3.4.0.tgz",
+      "integrity": "sha1-O97q/ucgqdfAa+vlIdD3JIJKmTM=",
+      "dev": true,
+      "requires": {
+        "benchmark": "2.1.4",
+        "chalk": "1.1.3",
+        "docopt": "0.6.2",
+        "easy-table": "1.1.0"
       }
     },
     "bindings": {
@@ -107,6 +125,27 @@
         "type-detect": "1.0.0"
       }
     },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.2",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "character-entities": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
@@ -136,6 +175,13 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
       "dev": true
+    },
+    "clone": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+      "dev": true,
+      "optional": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -204,6 +250,16 @@
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
       "dev": true
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "clone": "1.0.2"
+      }
+    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -220,6 +276,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+    },
+    "docopt": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
+      "integrity": "sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=",
+      "dev": true
     },
     "doctoc": {
       "version": "1.3.0",
@@ -276,6 +338,15 @@
       "requires": {
         "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
+      }
+    },
+    "easy-table": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
+      "integrity": "sha1-hvmrTBAvA3G3KXuSplHVgkvIy3M=",
+      "dev": true,
+      "requires": {
+        "wcwidth": "1.0.1"
       }
     },
     "emoji-regex": {
@@ -368,6 +439,15 @@
       "dev": true,
       "requires": {
         "function-bind": "1.1.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
       }
     },
     "has-unicode": {
@@ -1075,6 +1155,16 @@
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.2.tgz",
       "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU=",
       "dev": true
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "defaults": "1.0.3"
+      }
     },
     "wide-align": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   ],
   "scripts": {
     "bootstrap": "bin/nearleyc.js lib/nearley-language-bootstrapped.ne > tmp && mv tmp lib/nearley-language-bootstrapped.js",
-    "test": "mocha test/launch.js",
-    "benchmark": "node test/benchmark.js",
+    "benchmark": "benchr test/benchmark.js",
     "doctoc": "doctoc --notitle README.md"
   },
   "author": "Hardmath123",
@@ -39,7 +38,7 @@
   "devDependencies": {
     "@types/moo": "^0.3.0",
     "@types/node": "^7.0.27",
-    "benchmark": "^2.1.3",
+    "benchr": "^3.2.0",
     "chai": "^3.4.1",
     "coffee-script": "^1.10.0",
     "doctoc": "^1.3.0",

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,24 +1,6 @@
 
-var path = require('path');
-
-var Benchmark = require('benchmark');
-
-var Parser = require('../lib/nearley.js').Parser;
-var shared = require('./_shared.js');
-var compile = shared.compile
-  , read = shared.read;
-
-
-// For making tests
-
-function addTest(parserName, parser, examples) {
-    examples.forEach(function(example) {
-        var input = example.source;
-        suite.add(parserName + ' ' + example.name, function() {
-            parser(input);
-        });
-    })
-}
+const nearley = require('../lib/nearley.js');
+const {compile, read} = require('./_shared.js');
 
 function makeParser(neFile) {
     var grammar;
@@ -28,70 +10,42 @@ function makeParser(neFile) {
         grammar = null; // oh dear
     }
 
-    function parse(input) {
+    return function parse(input) {
         if (grammar === null) {
             throw 'grammar error';
         }
-        var p = new Parser(grammar);
+        var p = new nearley.Parser(grammar);
         p.feed(input);
         return p.results;
     }
-
-    return parse;
 }
 
-function Example(name, source) {
-    this.name = name;
-    this.source = source;
-}
-
-Example.read = function(filename) {
-  return new Example(path.basename(filename), read(filename));
-};
 
 // Define benchmarks
 
-var suite = new Benchmark.Suite();
+suite('calculator', () => {
+  const exampleFile = 'ln (3 + 2*(8/e - sin(pi/5)))'
 
-addTest('calculator', makeParser('examples/calculator/arithmetic.ne'), [
-    // new Example('arithmetic1', '2 + 3 * 42 - sin(0.14)'),
-    new Example('arithmetic2', 'ln (3 + 2*(8/e - sin(pi/5)))'),
-]);
+  const parse = makeParser('examples/calculator/arithmetic.ne')
+  benchmark('nearley', () => parse(exampleFile))
 
-addTest('json', makeParser('examples/json.ne'), [
-    Example.read('test/sample1k.json'),
-]);
-
-addTest('tosh', makeParser('examples/tosh.ne'), [
-    new Example('ex1', 'set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))'),
-]);
-
-
-
-/*
-addTest('native JSON.parse', JSON.parse, [
-   Example.read('test/test1.json'),
-   Example.read('test/test2.json'),
-])
-*/
-
-// TODO benchmark compile
-
-
-// Run & report results
-
-suite.on('cycle', function(event) {
-    var bench = event.target;
-    if (bench.error) {
-        console.log('  ✘ ', bench.name);
-        console.log(bench.error.stack);
-        console.log('');
-    } else {
-        console.log('  ✔ ' + bench)
-    }
 })
-.on('complete', function() {
-    // TODO: report geometric mean.
+
+suite('json', () => {
+  const jsonFile = read('test/sample1k.json')
+
+  const parse = makeParser('examples/json.ne')
+  benchmark('nearley', () => parse(jsonFile))
+
+  //benchmark('native JSON 😛', () => JSON.parse(jsonFile))
+
 })
-.run();
+
+suite('tosh', () => {
+  const toshFile = 'set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))'
+
+  const parse = makeParser('examples/tosh.ne')
+  benchmark('nearley', () => parse(toshFile))
+
+})
 


### PR DESCRIPTION
This halves the amount of code in `benchmarks.js`, makes it easier to compare benchmarks across different libraries if we want to do that, and makes it easier to add new benchmarks. :-)