### PR TITLE
Optimise docs site

### DIFF
--- a/docs/accessing-parse-table.html
+++ b/docs/accessing-parse-table.html
@@ -5,8 +5,6 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link href='https://fonts.googleapis.com/css?family=Roboto:300,700'
-              rel='stylesheet' type='text/css'/>
         <link rel="stylesheet" type="text/css" href="/www/main.css"/>
     </head>
     <body class="docs-page">
@@ -56,5 +54,20 @@ parser.feed(...);
             <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
             <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
         </div>
+
+        <script>
+        WebFontConfig = {
+          google: {
+            families: ['Roboto:300,700']
+          }
+        };
+
+        (function(d) {
+          var wf = d.createElement('script'), s = d.scripts[0]
+          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
+          wf.async = true
+          s.parentNode.insertBefore(wf, s)
+        })(document)
+        </script>
     </body>
 </html>

--- a/docs/accessing-parse-table.html
+++ b/docs/accessing-parse-table.html
@@ -257,6 +257,8 @@ nav a {
 
 
 </style>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -277,22 +279,22 @@ nav a {
             <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.10.4</span></a></h1>
 
 <h2>Accessing the parse table</h2>
-<p class="lang-highlight">If you are familiar with the Earley parsing algorithm, you can access the
-internal parse table using <code class="lang-css"><span class="hljs-tag">Parser</span><span class="hljs-class">.table</span></code> (this, for example, is how
-<code class="lang-stata">nearley-<span class="hljs-keyword">test</span></code> works). One caveat, however: you must pass the <code class="lang-pf"><span class="hljs-keyword">keep</span>History</code>
+<p>If you are familiar with the Earley parsing algorithm, you can access the
+internal parse table using <code>Parser.table</code> (this, for example, is how
+<code>nearley-test</code> works). One caveat, however: you must pass the <code>keepHistory</code>
 option to nearley to prevent it from garbage-collecting inaccessible columns of
 the table.</p>
-<pre class="lang-highlight"><code class="lang-js"><span class="hljs-keyword">const</span> nearley = <span class="hljs-built_in">require</span>(<span class="hljs-string">"nearley"</span>);
-<span class="hljs-keyword">const</span> grammar = <span class="hljs-built_in">require</span>(<span class="hljs-string">"./grammar"</span>);
+<pre><code class="lang-js">const nearley = require(&quot;nearley&quot;);
+const grammar = require(&quot;./grammar&quot;);
 
-<span class="hljs-keyword">const</span> parser = <span class="hljs-keyword">new</span> nearley.Parser(
+const parser = new nearley.Parser(
     nearley.Grammar.fromCompiled(grammar),
-    { keepHistory: <span class="hljs-literal">true</span> }
+    { keepHistory: true }
 );
 
 
 parser.feed(...);
-<span class="hljs-built_in">console</span>.log(parser.table);
+console.log(parser.table);
 </code></pre>
 
 

--- a/docs/accessing-parse-table.html
+++ b/docs/accessing-parse-table.html
@@ -5,7 +5,258 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link rel="stylesheet" type="text/css" href="/www/main.css"/>
+<style>
+body {
+    font-family: sans-serif;
+    font-weight: 300;
+    font-size: 15pt;
+    margin: 0px;
+    padding: 0px;
+    border-top: 0.1em #559 solid;
+    border-bottom: 0.1em #559 solid;
+}
+
+.wf-roboto-n3-active body {
+  font-family: Roboto, sans-serif;
+}
+
+#main a {
+    color: #55a;
+}
+#main a:visited {
+    color: #55a;
+}
+#main a:hover {
+    color: #259;
+}
+
+h1 {
+    font-size: 1.6em;
+    font-weight: 100;
+    letter-spacing: 0.5em;
+    text-align: center;
+    margin-top: 3em;
+    margin-bottom: 3em;
+}
+
+h1 a {
+    text-decoration: none;
+}
+
+h1:hover {
+    color: #559;
+    cursor: pointer;
+}
+
+#version {
+    background: orange;
+    border-radius: 50%;
+    font-weight: bold;
+    color: white;
+    width: 3.5em;
+    height: 3.5em;
+    display: inline-block;
+    text-align: center;
+    line-height: 3.5em;
+    letter-spacing: 0em;
+}
+
+h2 {
+    margin-top: 4em;
+}
+h3 {
+    margin-top: 3em;
+}
+h4 {
+    margin-top: 3em;
+}
+
+.center {
+    padding-left: 2em;
+    padding-right: 2em;
+    margin-left: auto;
+    margin-right: auto;
+}
+#main {
+    max-width: 35em;
+}
+
+#main p, ul, ol {
+    line-height: 1.5em;
+    margin-bottom: 1em;
+}
+
+#main li {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+#main ul li {
+    list-style: none;
+    min-width: 10em;
+}
+#main ul li:before {
+    display: inline-block;
+    content: &quot;\2014&quot;;
+    margin-left: -1.5em;
+    width: 1.5em;
+}
+
+#main textarea {
+    width: 100%;
+    height: 20em;
+    resize: none;
+    margin-top: 5px;
+    margin-bottom: 5px;
+
+    font-family: menlo, monaco, monospace;
+    font-size: 10pt;
+    padding: 5px;
+
+    border: none;
+    border-left: solid 1px #aaa;
+}
+#main textarea:focus {
+    outline: none;
+}
+
+#main img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 100%;
+}
+img + .caption {
+    text-align: center;
+    font-size: 0.7em;
+    color: #aaa;
+}
+
+/*
+#cy-viz {
+    width: 100%;
+}*/
+
+#footer {
+    margin-top: 10em;
+    color: #aaa;
+    font-size: 0.7em;
+    padding: 5em;
+}
+
+code {
+    margin-left: 0.2em;
+    margin-right: 0.2em;
+    padding: 0.2em;
+    border-radius: 0.2em;
+    background-color: #eee;
+}
+
+pre code {
+    border-radius: 0.5em;
+    //background-color: #559;
+    //color: white;
+    //text-shadow: 0em 0em 0.2em black;
+    padding: 0.5em;
+    display: block;
+    overflow: auto;
+}
+
+
+ol.tutorial {
+    counter-reset: tutorial-counter;
+}
+
+ol.tutorial li {
+    list-style: none;
+}
+
+ol.tutorial li:before {
+    content: counter(tutorial-counter);
+    counter-increment: tutorial-counter;
+
+    font-weight: bold;
+    border-radius: 50%;
+    background-color: #559;
+    width: 2em;
+    height: 2em;
+    display: inline-block;
+    text-align: center;
+    line-height: 2em;
+    color: white;
+
+    margin-left: -2em;
+
+    position: relative;
+    right: 1em;
+}
+
+input[type&#x3D;&quot;text&quot;] {
+    border: none;
+    font-family: monospace;
+    font-size: 1em;
+    color: #559;
+}
+
+input[type&#x3D;&quot;text&quot;]:focus {
+    outline: none;
+}
+
+
+nav {
+    border-right: 1px solid #aaa;
+    background: #fff;
+}
+nav ul {
+    padding: 0;
+    margin: 0;
+}
+nav a {
+    text-decoration: none;
+    color: #000;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0.25em 0.5em; */
+}
+.page {
+    display: block;
+    border-bottom: 1px solid #aaa;
+}
+
+.page-title-active {
+    background: #559;
+    color: #fff;
+}
+
+.page-heading {
+    display: block;
+    padding-left: 1em;
+}
+
+
+@media screen and (min-width: 36rem) {
+    nav {
+        position: fixed;
+        width: 16rem;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        white-space: nowrap;
+        overflow-y: auto;
+        font-size: 1rem;
+    }
+    body.docs-page {
+        margin-left: 16rem;
+    }
+}
+
+/* highlight.js */
+
+.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
+
+
+</style>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>

--- a/docs/accessing-parse-table.html
+++ b/docs/accessing-parse-table.html
@@ -257,8 +257,6 @@ nav a {
 
 
 </style>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -314,13 +312,13 @@ console.log(parser.table);
             families: ['Roboto:300,700']
           }
         };
-
-        (function(d) {
-          var wf = d.createElement('script'), s = d.scripts[0]
-          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
-          wf.async = true
-          s.parentNode.insertBefore(wf, s)
-        })(document)
+        </script>
+        <script async src="//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js"></script>
+        <script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>
+        document.querySelector('#highlight-js').addEventListener('load', function() {
+          hljs.initHighlightingOnLoad();
+        })
         </script>
     </body>
 </html>

--- a/docs/custom-tokens-and-lexers.html
+++ b/docs/custom-tokens-and-lexers.html
@@ -5,8 +5,6 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link href='https://fonts.googleapis.com/css?family=Roboto:300,700'
-              rel='stylesheet' type='text/css'/>
         <link rel="stylesheet" type="text/css" href="/www/main.css"/>
     </head>
     <body class="docs-page">
@@ -82,5 +80,20 @@ example</a></p>
             <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
             <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
         </div>
+
+        <script>
+        WebFontConfig = {
+          google: {
+            families: ['Roboto:300,700']
+          }
+        };
+
+        (function(d) {
+          var wf = d.createElement('script'), s = d.scripts[0]
+          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
+          wf.async = true
+          s.parentNode.insertBefore(wf, s)
+        })(document)
+        </script>
     </body>
 </html>

--- a/docs/custom-tokens-and-lexers.html
+++ b/docs/custom-tokens-and-lexers.html
@@ -257,8 +257,6 @@ nav a {
 
 
 </style>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -340,13 +338,13 @@ example</a></p>
             families: ['Roboto:300,700']
           }
         };
-
-        (function(d) {
-          var wf = d.createElement('script'), s = d.scripts[0]
-          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
-          wf.async = true
-          s.parentNode.insertBefore(wf, s)
-        })(document)
+        </script>
+        <script async src="//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js"></script>
+        <script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>
+        document.querySelector('#highlight-js').addEventListener('load', function() {
+          hljs.initHighlightingOnLoad();
+        })
         </script>
     </body>
 </html>

--- a/docs/custom-tokens-and-lexers.html
+++ b/docs/custom-tokens-and-lexers.html
@@ -5,7 +5,258 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link rel="stylesheet" type="text/css" href="/www/main.css"/>
+<style>
+body {
+    font-family: sans-serif;
+    font-weight: 300;
+    font-size: 15pt;
+    margin: 0px;
+    padding: 0px;
+    border-top: 0.1em #559 solid;
+    border-bottom: 0.1em #559 solid;
+}
+
+.wf-roboto-n3-active body {
+  font-family: Roboto, sans-serif;
+}
+
+#main a {
+    color: #55a;
+}
+#main a:visited {
+    color: #55a;
+}
+#main a:hover {
+    color: #259;
+}
+
+h1 {
+    font-size: 1.6em;
+    font-weight: 100;
+    letter-spacing: 0.5em;
+    text-align: center;
+    margin-top: 3em;
+    margin-bottom: 3em;
+}
+
+h1 a {
+    text-decoration: none;
+}
+
+h1:hover {
+    color: #559;
+    cursor: pointer;
+}
+
+#version {
+    background: orange;
+    border-radius: 50%;
+    font-weight: bold;
+    color: white;
+    width: 3.5em;
+    height: 3.5em;
+    display: inline-block;
+    text-align: center;
+    line-height: 3.5em;
+    letter-spacing: 0em;
+}
+
+h2 {
+    margin-top: 4em;
+}
+h3 {
+    margin-top: 3em;
+}
+h4 {
+    margin-top: 3em;
+}
+
+.center {
+    padding-left: 2em;
+    padding-right: 2em;
+    margin-left: auto;
+    margin-right: auto;
+}
+#main {
+    max-width: 35em;
+}
+
+#main p, ul, ol {
+    line-height: 1.5em;
+    margin-bottom: 1em;
+}
+
+#main li {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+#main ul li {
+    list-style: none;
+    min-width: 10em;
+}
+#main ul li:before {
+    display: inline-block;
+    content: &quot;\2014&quot;;
+    margin-left: -1.5em;
+    width: 1.5em;
+}
+
+#main textarea {
+    width: 100%;
+    height: 20em;
+    resize: none;
+    margin-top: 5px;
+    margin-bottom: 5px;
+
+    font-family: menlo, monaco, monospace;
+    font-size: 10pt;
+    padding: 5px;
+
+    border: none;
+    border-left: solid 1px #aaa;
+}
+#main textarea:focus {
+    outline: none;
+}
+
+#main img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 100%;
+}
+img + .caption {
+    text-align: center;
+    font-size: 0.7em;
+    color: #aaa;
+}
+
+/*
+#cy-viz {
+    width: 100%;
+}*/
+
+#footer {
+    margin-top: 10em;
+    color: #aaa;
+    font-size: 0.7em;
+    padding: 5em;
+}
+
+code {
+    margin-left: 0.2em;
+    margin-right: 0.2em;
+    padding: 0.2em;
+    border-radius: 0.2em;
+    background-color: #eee;
+}
+
+pre code {
+    border-radius: 0.5em;
+    //background-color: #559;
+    //color: white;
+    //text-shadow: 0em 0em 0.2em black;
+    padding: 0.5em;
+    display: block;
+    overflow: auto;
+}
+
+
+ol.tutorial {
+    counter-reset: tutorial-counter;
+}
+
+ol.tutorial li {
+    list-style: none;
+}
+
+ol.tutorial li:before {
+    content: counter(tutorial-counter);
+    counter-increment: tutorial-counter;
+
+    font-weight: bold;
+    border-radius: 50%;
+    background-color: #559;
+    width: 2em;
+    height: 2em;
+    display: inline-block;
+    text-align: center;
+    line-height: 2em;
+    color: white;
+
+    margin-left: -2em;
+
+    position: relative;
+    right: 1em;
+}
+
+input[type&#x3D;&quot;text&quot;] {
+    border: none;
+    font-family: monospace;
+    font-size: 1em;
+    color: #559;
+}
+
+input[type&#x3D;&quot;text&quot;]:focus {
+    outline: none;
+}
+
+
+nav {
+    border-right: 1px solid #aaa;
+    background: #fff;
+}
+nav ul {
+    padding: 0;
+    margin: 0;
+}
+nav a {
+    text-decoration: none;
+    color: #000;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0.25em 0.5em; */
+}
+.page {
+    display: block;
+    border-bottom: 1px solid #aaa;
+}
+
+.page-title-active {
+    background: #559;
+    color: #fff;
+}
+
+.page-heading {
+    display: block;
+    padding-left: 1em;
+}
+
+
+@media screen and (min-width: 36rem) {
+    nav {
+        position: fixed;
+        width: 16rem;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        white-space: nowrap;
+        overflow-y: auto;
+        font-size: 1rem;
+    }
+    body.docs-page {
+        margin-left: 16rem;
+    }
+}
+
+/* highlight.js */
+
+.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
+
+
+</style>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>

--- a/docs/custom-tokens-and-lexers.html
+++ b/docs/custom-tokens-and-lexers.html
@@ -257,6 +257,8 @@ nav a {
 
 
 </style>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -285,35 +287,35 @@ nav a {
 <h3 id="custom-token-matchers">Custom token matchers</h3>
 <p>Aside from the lexer infrastructure, nearley provides a lightweight way to
 parse arbitrary streams.</p>
-<p class="lang-highlight">Custom matchers can be defined in two ways: <em>literal</em> tokens and <em>testable</em>
-tokens. A literal token matches a JS value exactly (with <code class="lang-haml">=<span class="ruby">==</span></code>), while a
+<p>Custom matchers can be defined in two ways: <em>literal</em> tokens and <em>testable</em>
+tokens. A literal token matches a JS value exactly (with <code>===</code>), while a
 testable token runs a predicate that tests whether or not the value matches.</p>
-<p class="lang-highlight">Note that in this case, you would feed a <code>Parser</code> instance an <em>array</em> of
+<p>Note that in this case, you would feed a <code>Parser</code> instance an <em>array</em> of
 objects rather than a string! Here is a simple example:</p>
-<pre class="lang-highlight"><code class="lang-coffeescript">@{%
-const tokenPrint = { <span class="hljs-attribute">literal</span>: <span class="hljs-string">"print"</span> };
-const tokenNumber = { <span class="hljs-attribute">test</span>: x =&gt; Number.isInteger(x) };
+<pre><code class="lang-coffeescript">@{%
+const tokenPrint = { literal: &quot;print&quot; };
+const tokenNumber = { test: x =&gt; Number.isInteger(x) };
 %}
 
-main -&gt; %tokenPrint %tokenNumber <span class="hljs-string">";;"</span>
+main -&gt; %tokenPrint %tokenNumber &quot;;;&quot;
 
-<span class="hljs-comment"># parser.feed(["print", 12, ";;"]);</span>
+# parser.feed([&quot;print&quot;, 12, &quot;;;&quot;]);
 </code></pre>
 <h3 id="custom-lexers">Custom lexers</h3>
 <p>nearley recommends using a <a href="https://github.com/tjvr/moo">moo</a>-based lexer.
 However, you can use any lexer that conforms to the following interface:</p>
 <ul>
-<li class="lang-highlight"><code class="lang-stylus"><span class="hljs-function"><span class="hljs-title">next</span><span class="hljs-params">()</span></span></code> returns a token object, which could have fields for line number,
-etc. Importantly, a token object <em>must</em> have a <code class="lang-ceylon"><span class="hljs-keyword">value</span></code> attribute.</li>
-<li class="lang-highlight"><code class="lang-stylus"><span class="hljs-function"><span class="hljs-title">save</span><span class="hljs-params">()</span></span></code> returns an info object that describes the current state of the
+<li><code>next()</code> returns a token object, which could have fields for line number,
+etc. Importantly, a token object <em>must</em> have a <code>value</code> attribute.</li>
+<li><code>save()</code> returns an info object that describes the current state of the
 lexer. nearley places no restrictions on this object.</li>
-<li class="lang-highlight"><code class="lang-stylus"><span class="hljs-function"><span class="hljs-title">reset</span><span class="hljs-params">(chunk, info)</span></span></code> sets the internal buffer of the lexer to <code>chunk</code>, and
-restores its state to a state returned by <code class="lang-stylus"><span class="hljs-function"><span class="hljs-title">save</span><span class="hljs-params">()</span></span></code>.</li>
-<li class="lang-highlight"><code class="lang-stylus"><span class="hljs-function"><span class="hljs-title">formatError</span><span class="hljs-params">(token)</span></span></code> returns a string with an error message describing a
+<li><code>reset(chunk, info)</code> sets the internal buffer of the lexer to <code>chunk</code>, and
+restores its state to a state returned by <code>save()</code>.</li>
+<li><code>formatError(token)</code> returns a string with an error message describing a
 parse error at that token (for example, the string might contain the line and
 column where the error was found).</li>
-<li class="lang-highlight"><code class="lang-stylus"><span class="hljs-function"><span class="hljs-title">has</span><span class="hljs-params">(name)</span></span></code> returns true if the lexer can emit tokens with that name. This is
-used to resolve <code class="lang-erlang-repl"><span class="hljs-comment">%</span></code>-specifiers in compiled nearley grammars.</li>
+<li><code>has(name)</code> returns true if the lexer can emit tokens with that name. This is
+used to resolve <code>%</code>-specifiers in compiled nearley grammars.</li>
 </ul>
 <blockquote>
 <p>Note: if you are searching for a lexer that allows indentation-aware

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -257,8 +257,6 @@ nav a {
 
 
 </style>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -353,13 +351,13 @@ several additional utilities for building languages</p>
             families: ['Roboto:300,700']
           }
         };
-
-        (function(d) {
-          var wf = d.createElement('script'), s = d.scripts[0]
-          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
-          wf.async = true
-          s.parentNode.insertBefore(wf, s)
-        })(document)
+        </script>
+        <script async src="//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js"></script>
+        <script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>
+        document.querySelector('#highlight-js').addEventListener('load', function() {
+          hljs.initHighlightingOnLoad();
+        })
         </script>
     </body>
 </html>

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -5,7 +5,258 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link rel="stylesheet" type="text/css" href="/www/main.css"/>
+<style>
+body {
+    font-family: sans-serif;
+    font-weight: 300;
+    font-size: 15pt;
+    margin: 0px;
+    padding: 0px;
+    border-top: 0.1em #559 solid;
+    border-bottom: 0.1em #559 solid;
+}
+
+.wf-roboto-n3-active body {
+  font-family: Roboto, sans-serif;
+}
+
+#main a {
+    color: #55a;
+}
+#main a:visited {
+    color: #55a;
+}
+#main a:hover {
+    color: #259;
+}
+
+h1 {
+    font-size: 1.6em;
+    font-weight: 100;
+    letter-spacing: 0.5em;
+    text-align: center;
+    margin-top: 3em;
+    margin-bottom: 3em;
+}
+
+h1 a {
+    text-decoration: none;
+}
+
+h1:hover {
+    color: #559;
+    cursor: pointer;
+}
+
+#version {
+    background: orange;
+    border-radius: 50%;
+    font-weight: bold;
+    color: white;
+    width: 3.5em;
+    height: 3.5em;
+    display: inline-block;
+    text-align: center;
+    line-height: 3.5em;
+    letter-spacing: 0em;
+}
+
+h2 {
+    margin-top: 4em;
+}
+h3 {
+    margin-top: 3em;
+}
+h4 {
+    margin-top: 3em;
+}
+
+.center {
+    padding-left: 2em;
+    padding-right: 2em;
+    margin-left: auto;
+    margin-right: auto;
+}
+#main {
+    max-width: 35em;
+}
+
+#main p, ul, ol {
+    line-height: 1.5em;
+    margin-bottom: 1em;
+}
+
+#main li {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+#main ul li {
+    list-style: none;
+    min-width: 10em;
+}
+#main ul li:before {
+    display: inline-block;
+    content: &quot;\2014&quot;;
+    margin-left: -1.5em;
+    width: 1.5em;
+}
+
+#main textarea {
+    width: 100%;
+    height: 20em;
+    resize: none;
+    margin-top: 5px;
+    margin-bottom: 5px;
+
+    font-family: menlo, monaco, monospace;
+    font-size: 10pt;
+    padding: 5px;
+
+    border: none;
+    border-left: solid 1px #aaa;
+}
+#main textarea:focus {
+    outline: none;
+}
+
+#main img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 100%;
+}
+img + .caption {
+    text-align: center;
+    font-size: 0.7em;
+    color: #aaa;
+}
+
+/*
+#cy-viz {
+    width: 100%;
+}*/
+
+#footer {
+    margin-top: 10em;
+    color: #aaa;
+    font-size: 0.7em;
+    padding: 5em;
+}
+
+code {
+    margin-left: 0.2em;
+    margin-right: 0.2em;
+    padding: 0.2em;
+    border-radius: 0.2em;
+    background-color: #eee;
+}
+
+pre code {
+    border-radius: 0.5em;
+    //background-color: #559;
+    //color: white;
+    //text-shadow: 0em 0em 0.2em black;
+    padding: 0.5em;
+    display: block;
+    overflow: auto;
+}
+
+
+ol.tutorial {
+    counter-reset: tutorial-counter;
+}
+
+ol.tutorial li {
+    list-style: none;
+}
+
+ol.tutorial li:before {
+    content: counter(tutorial-counter);
+    counter-increment: tutorial-counter;
+
+    font-weight: bold;
+    border-radius: 50%;
+    background-color: #559;
+    width: 2em;
+    height: 2em;
+    display: inline-block;
+    text-align: center;
+    line-height: 2em;
+    color: white;
+
+    margin-left: -2em;
+
+    position: relative;
+    right: 1em;
+}
+
+input[type&#x3D;&quot;text&quot;] {
+    border: none;
+    font-family: monospace;
+    font-size: 1em;
+    color: #559;
+}
+
+input[type&#x3D;&quot;text&quot;]:focus {
+    outline: none;
+}
+
+
+nav {
+    border-right: 1px solid #aaa;
+    background: #fff;
+}
+nav ul {
+    padding: 0;
+    margin: 0;
+}
+nav a {
+    text-decoration: none;
+    color: #000;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0.25em 0.5em; */
+}
+.page {
+    display: block;
+    border-bottom: 1px solid #aaa;
+}
+
+.page-title-active {
+    background: #559;
+    color: #fff;
+}
+
+.page-heading {
+    display: block;
+    padding-left: 1em;
+}
+
+
+@media screen and (min-width: 36rem) {
+    nav {
+        position: fixed;
+        width: 16rem;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        white-space: nowrap;
+        overflow-y: auto;
+        font-size: 1rem;
+    }
+    body.docs-page {
+        margin-left: 16rem;
+    }
+}
+
+/* highlight.js */
+
+.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
+
+
+</style>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -5,8 +5,6 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link href='https://fonts.googleapis.com/css?family=Roboto:300,700'
-              rel='stylesheet' type='text/css'/>
         <link rel="stylesheet" type="text/css" href="/www/main.css"/>
     </head>
     <body class="docs-page">
@@ -95,5 +93,20 @@ several additional utilities for building languages</p>
             <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
             <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
         </div>
+
+        <script>
+        WebFontConfig = {
+          google: {
+            families: ['Roboto:300,700']
+          }
+        };
+
+        (function(d) {
+          var wf = d.createElement('script'), s = d.scripts[0]
+          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
+          wf.async = true
+          s.parentNode.insertBefore(wf, s)
+        })(document)
+        </script>
     </body>
 </html>

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -257,6 +257,8 @@ nav a {
 
 
 </style>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -309,7 +311,7 @@ to obtain a <em>string</em></p>
 <p><strong>abstract syntax tree (AST)</strong>: a version of a <em>parse tree</em> that has undergone
 some <em>postprocessors</em> to simplify it (for example, an AST is likely to omit
 whitespace)</p>
-<p class="lang-highlight"><strong>preprocessor</strong>: the dialect of JavaScript targeted by <code>nearleyc</code>; for
+<p><strong>preprocessor</strong>: the dialect of JavaScript targeted by <code>nearleyc</code>; for
 example, you can emit TypeScript code instead of plain JavaScript (not to be
 confused with <em>postprocessor</em>)</p>
 <p><strong>postprocessor</strong>: a function associated with a production rule, whose purpose

--- a/docs/how-to-grammar-good.html
+++ b/docs/how-to-grammar-good.html
@@ -5,7 +5,258 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link rel="stylesheet" type="text/css" href="/www/main.css"/>
+<style>
+body {
+    font-family: sans-serif;
+    font-weight: 300;
+    font-size: 15pt;
+    margin: 0px;
+    padding: 0px;
+    border-top: 0.1em #559 solid;
+    border-bottom: 0.1em #559 solid;
+}
+
+.wf-roboto-n3-active body {
+  font-family: Roboto, sans-serif;
+}
+
+#main a {
+    color: #55a;
+}
+#main a:visited {
+    color: #55a;
+}
+#main a:hover {
+    color: #259;
+}
+
+h1 {
+    font-size: 1.6em;
+    font-weight: 100;
+    letter-spacing: 0.5em;
+    text-align: center;
+    margin-top: 3em;
+    margin-bottom: 3em;
+}
+
+h1 a {
+    text-decoration: none;
+}
+
+h1:hover {
+    color: #559;
+    cursor: pointer;
+}
+
+#version {
+    background: orange;
+    border-radius: 50%;
+    font-weight: bold;
+    color: white;
+    width: 3.5em;
+    height: 3.5em;
+    display: inline-block;
+    text-align: center;
+    line-height: 3.5em;
+    letter-spacing: 0em;
+}
+
+h2 {
+    margin-top: 4em;
+}
+h3 {
+    margin-top: 3em;
+}
+h4 {
+    margin-top: 3em;
+}
+
+.center {
+    padding-left: 2em;
+    padding-right: 2em;
+    margin-left: auto;
+    margin-right: auto;
+}
+#main {
+    max-width: 35em;
+}
+
+#main p, ul, ol {
+    line-height: 1.5em;
+    margin-bottom: 1em;
+}
+
+#main li {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+#main ul li {
+    list-style: none;
+    min-width: 10em;
+}
+#main ul li:before {
+    display: inline-block;
+    content: &quot;\2014&quot;;
+    margin-left: -1.5em;
+    width: 1.5em;
+}
+
+#main textarea {
+    width: 100%;
+    height: 20em;
+    resize: none;
+    margin-top: 5px;
+    margin-bottom: 5px;
+
+    font-family: menlo, monaco, monospace;
+    font-size: 10pt;
+    padding: 5px;
+
+    border: none;
+    border-left: solid 1px #aaa;
+}
+#main textarea:focus {
+    outline: none;
+}
+
+#main img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 100%;
+}
+img + .caption {
+    text-align: center;
+    font-size: 0.7em;
+    color: #aaa;
+}
+
+/*
+#cy-viz {
+    width: 100%;
+}*/
+
+#footer {
+    margin-top: 10em;
+    color: #aaa;
+    font-size: 0.7em;
+    padding: 5em;
+}
+
+code {
+    margin-left: 0.2em;
+    margin-right: 0.2em;
+    padding: 0.2em;
+    border-radius: 0.2em;
+    background-color: #eee;
+}
+
+pre code {
+    border-radius: 0.5em;
+    //background-color: #559;
+    //color: white;
+    //text-shadow: 0em 0em 0.2em black;
+    padding: 0.5em;
+    display: block;
+    overflow: auto;
+}
+
+
+ol.tutorial {
+    counter-reset: tutorial-counter;
+}
+
+ol.tutorial li {
+    list-style: none;
+}
+
+ol.tutorial li:before {
+    content: counter(tutorial-counter);
+    counter-increment: tutorial-counter;
+
+    font-weight: bold;
+    border-radius: 50%;
+    background-color: #559;
+    width: 2em;
+    height: 2em;
+    display: inline-block;
+    text-align: center;
+    line-height: 2em;
+    color: white;
+
+    margin-left: -2em;
+
+    position: relative;
+    right: 1em;
+}
+
+input[type&#x3D;&quot;text&quot;] {
+    border: none;
+    font-family: monospace;
+    font-size: 1em;
+    color: #559;
+}
+
+input[type&#x3D;&quot;text&quot;]:focus {
+    outline: none;
+}
+
+
+nav {
+    border-right: 1px solid #aaa;
+    background: #fff;
+}
+nav ul {
+    padding: 0;
+    margin: 0;
+}
+nav a {
+    text-decoration: none;
+    color: #000;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0.25em 0.5em; */
+}
+.page {
+    display: block;
+    border-bottom: 1px solid #aaa;
+}
+
+.page-title-active {
+    background: #559;
+    color: #fff;
+}
+
+.page-heading {
+    display: block;
+    padding-left: 1em;
+}
+
+
+@media screen and (min-width: 36rem) {
+    nav {
+        position: fixed;
+        width: 16rem;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        white-space: nowrap;
+        overflow-y: auto;
+        font-size: 1rem;
+    }
+    body.docs-page {
+        margin-left: 16rem;
+    }
+}
+
+/* highlight.js */
+
+.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
+
+
+</style>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>

--- a/docs/how-to-grammar-good.html
+++ b/docs/how-to-grammar-good.html
@@ -257,8 +257,6 @@ nav a {
 
 
 </style>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -410,13 +408,13 @@ prototype and design.</p>
             families: ['Roboto:300,700']
           }
         };
-
-        (function(d) {
-          var wf = d.createElement('script'), s = d.scripts[0]
-          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
-          wf.async = true
-          s.parentNode.insertBefore(wf, s)
-        })(document)
+        </script>
+        <script async src="//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js"></script>
+        <script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>
+        document.querySelector('#highlight-js').addEventListener('load', function() {
+          hljs.initHighlightingOnLoad();
+        })
         </script>
     </body>
 </html>

--- a/docs/how-to-grammar-good.html
+++ b/docs/how-to-grammar-good.html
@@ -257,6 +257,8 @@ nav a {
 
 
 </style>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -306,86 +308,86 @@ algorithm and some basic concepts. From here on out, I’m assuming you know wha
 <em>regular expression</em>, <em>Backus Naur Form</em>, <em>context free grammar</em>, <em>terminal</em>,
 <em>nonterminal</em>, and <em>ambiguous grammar</em> mean. You should know nearley syntax
 well enough to understand what something like</p>
-<pre class="lang-highlight"><code class="lang-cpp"><span class="hljs-keyword">int</span> -&gt; [<span class="hljs-number">0</span>-<span class="hljs-number">9</span>]        {% id %}
-    | <span class="hljs-keyword">int</span> [<span class="hljs-number">0</span>-<span class="hljs-number">9</span>]     {% function(d) {<span class="hljs-keyword">return</span> d[<span class="hljs-number">0</span>] + d[<span class="hljs-number">1</span>]} %}
+<pre><code>int -&gt; [0-9]        {% id %}
+    | int [0-9]     {% function(d) {return d[0] + d[1]} %}
 </code></pre><p>means (though I like to pride myself on the readability of nearley grammar…).</p>
 <h3 id="structure">Structure</h3>
 <p>Your grammar should be structured from the top down. The first few rules in a
 file should describe a general outline, and tiny details (terminals for
 whitespace, literals etc.) should be at the bottom. For example, if you’re
 writing a parser for Scheme, you would start with</p>
-<pre class="lang-highlight"><code class="lang-elixir"><span class="hljs-constant">Sourcefile </span>-&gt; (<span class="hljs-constant">S-</span>expression | <span class="hljs-constant">Comment)</span><span class="hljs-symbol">:*</span>
-</code></pre><p class="lang-highlight">and then fill out what <code class="lang-mel">s-<span class="hljs-keyword">expression</span></code> and <code class="lang-sqf"><span class="hljs-built_in">comment</span></code> mean. Most of the time,
+<pre><code>Sourcefile -&gt; (S-expression | Comment):*
+</code></pre><p>and then fill out what <code>s-expression</code> and <code>comment</code> mean. Most of the time,
 rules defined higher in the file reference rules defined lower down, and rules
 defined near the bottom rarely ever reference rules near the top.</p>
 <h3 id="nonterminal-names">Nonterminal names</h3>
-<p class="lang-highlight">Give your nonterminals useful names–mostly nouns that describe the string it
+<p>Give your nonterminals useful names–mostly nouns that describe the string it
 will match. By convention, we use <code>_</code> for optional whitespace and <code>__</code> for
 mandatory whitespace: it makes it easy to write rules like</p>
-<pre class="lang-highlight"><code class="lang-mel"><span class="hljs-string">"("</span> _ <span class="hljs-keyword">expression</span> _ <span class="hljs-string">")"</span>
-</code></pre><p class="lang-highlight">You can explicitly mark a nonterminal as optional or repetitive by postfixing
-its name with <code>?</code> and <code class="lang-diff"><span class="hljs-addition">+</span></code> (respectively)–as in <code>statementlist+</code> or <code class="lang-sqf"><span class="hljs-built_in">comment</span>?</code>.
-Note that this has no semantic value: use nearley’s EBNF modifiers (<code class="lang-clojure"><span class="hljs-attribute">:*</span></code>, <code class="lang-clojure"><span class="hljs-attribute">:+</span></code>,
-<code class="lang-clojure"><span class="hljs-attribute">:?</span></code>) for that.</p>
+<pre><code>&quot;(&quot; _ expression _ &quot;)&quot;
+</code></pre><p>You can explicitly mark a nonterminal as optional or repetitive by postfixing
+its name with <code>?</code> and <code>+</code> (respectively)–as in <code>statementlist+</code> or <code>comment?</code>.
+Note that this has no semantic value: use nearley’s EBNF modifiers (<code>:*</code>, <code>:+</code>,
+<code>:?</code>) for that.</p>
 <h3 id="don-t-roll-your-own-unroller">Don’t roll your own unroller</h3>
 <p>If you want to match one or more of a nonterminal, use an EBNF modifier. It’s
 semantically legible, contextually appropriate and (most importantly) easy.
 It’s very easy to mess up and create an exponentially ambiguous monstrosity
 such as</p>
-<pre class="lang-highlight"><code class="lang-1c">lotsofletters -&gt; <span class="hljs-string">"a"</span> <span class="hljs-string">| lotsofletters lotsofletters</span>
+<pre><code>lotsofletters -&gt; &quot;a&quot; | lotsofletters lotsofletters
 </code></pre><h3 id="postprocess-or-dispose">Postprocess or dispose</h3>
-<p class="lang-highlight">nearley saves a nested array structure by default, but most of the time that’s
+<p>nearley saves a nested array structure by default, but most of the time that’s
 not what you want. For things like whitespace, you want to throw away all that
 useless information for memory efficiency, so use a postprocessor that just
-returns <code class="lang-actionscript"><span class="hljs-literal">null</span></code>. For syntactic sugar and stuff, construct object literals so
+returns <code>null</code>. For syntactic sugar and stuff, construct object literals so
 that the code that processes your AST is relatively independent of your
 grammar. Constructing object literals also lets you discard junk (parens,
 etc.).</p>
 <h3 id="remember-charclasses-aren-t-regexes">Remember, charclasses aren’t regexes</h3>
-<p class="lang-highlight">The <code class="lang-json">[a-z]</code> syntax only allows you to use regex-style character classes, not
+<p>The <code>[a-z]</code> syntax only allows you to use regex-style character classes, not
 actual regular expressions. Nearley fundamentally does not support regexes as
 terminals. Use EBNF modifiers instead–they do what you want.</p>
 <h3 id="debug-with-nearley-test">Debug with nearley-test</h3>
-<p class="lang-highlight">Use the <code class="lang-stata">nearley-<span class="hljs-keyword">test</span></code> script (installs alongside <code>nearleyc</code>) to debug your
+<p>Use the <code>nearley-test</code> script (installs alongside <code>nearleyc</code>) to debug your
 grammars. It lets you inspect the parse tables, and see all the parsings, or
 the point of failure. This is invaluable when you have a subtle ambiguity
 issue.</p>
 <h3 id="don-t-shy-away-from-left-recursion">Don’t shy away from left recursion</h3>
 <p>You were a good little student and you paid attention to your professors when
 they told you never to write grammars like:</p>
-<pre class="lang-highlight"><code class="lang-stylus"><span class="hljs-tag">a</span> -&gt; <span class="hljs-tag">a</span> <span class="hljs-string">"something"</span>
-</code></pre><p class="lang-highlight">because a naïve recursive-descent parser would bork in an infinite loop.
+<pre><code>a -&gt; a &quot;something&quot;
+</code></pre><p>because a naïve recursive-descent parser would bork in an infinite loop.
 Nearley, of course, is much better, so you don’t have to worry about that. If
 you’re paranoid about efficiency, you should actually prefer left recursion
-over right recursion (<code class="lang-autohotkey"><span class="hljs-literal">a</span> -&gt; <span class="hljs-string">"something"</span> <span class="hljs-literal">a</span></code>) because it’s very slightly faster.
+over right recursion (<code>a -&gt; &quot;something&quot; a</code>) because it’s very slightly faster.
 In any case, that’s how you deal with left or right associativity for binary
 operators.</p>
 <h3 id="do-shy-away-from-left-recursion">Do shy away from left recursion</h3>
-<p class="lang-highlight">…if you’re using it where the EBNF <code class="lang-clojure"><span class="hljs-attribute">:*</span></code> or <code class="lang-clojure"><span class="hljs-attribute">:+</span></code> makes more sense!</p>
+<p>…if you’re using it where the EBNF <code>:*</code> or <code>:+</code> makes more sense!</p>
 <h3 id="operator-precedence-is-not-black-magic">Operator precedence is not black magic</h3>
 <p>Here’s how you do it: you start with your lowest-precedence operator and work
 your way up to your highest precedence ones. Each operator gets its own
 nonterminal:</p>
-<pre class="lang-highlight"><code class="lang-livecodeserver">math -&gt; <span class="hljs-built_in">sum</span>
-<span class="hljs-built_in">sum</span> -&gt; <span class="hljs-built_in">sum</span> (<span class="hljs-string">"+"</span>|<span class="hljs-string">"-"</span>) product | product
-product -&gt; product (<span class="hljs-string">"*"</span>|<span class="hljs-string">"/"</span>) <span class="hljs-built_in">exp</span> | <span class="hljs-built_in">exp</span>
-<span class="hljs-built_in">exp</span> -&gt; <span class="hljs-built_in">number</span> <span class="hljs-string">"^"</span> <span class="hljs-built_in">exp</span> | <span class="hljs-built_in">number</span> <span class="hljs-comment"># this is right associative!</span>
-</code></pre><p class="lang-highlight">It should be pretty clear how this works, and how to extend it to different
+<pre><code>math -&gt; sum
+sum -&gt; sum (&quot;+&quot;|&quot;-&quot;) product | product
+product -&gt; product (&quot;*&quot;|&quot;/&quot;) exp | exp
+exp -&gt; number &quot;^&quot; exp | number # this is right associative!
+</code></pre><p>It should be pretty clear how this works, and how to extend it to different
 types of operators. The main thing is to be careful with your associativity
-direction. Be careful not to write <code class="lang-sml"><span class="hljs-keyword">op</span> -&gt; <span class="hljs-keyword">op</span> <span class="hljs-string">"$"</span> <span class="hljs-keyword">op</span></code>, because that’s ambiguous.</p>
-<p class="lang-highlight">Introducing non-conflicting unary negation (<code class="lang-1c"><span class="hljs-string">"5 * -5"</span></code>) is left as a trivial
+direction. Be careful not to write <code>op -&gt; op &quot;$&quot; op</code>, because that’s ambiguous.</p>
+<p>Introducing non-conflicting unary negation (<code>&quot;5 * -5&quot;</code>) is left as a trivial
 exercise for the enterprising reader.</p>
 <h3 id="comment-your-grammars">Comment your grammars</h3>
 <p>It’s very easy to come back to a grammar a week later and have no idea what
 it’s doing. Leave comments that explain precisely what each nonterminal
 matches, since a clear description will help you debug things in the future.</p>
 <h3 id="use-whitespace-prettily">Use whitespace prettily</h3>
-<p class="lang-highlight">Align your <code class="lang-diff"><span class="hljs-deletion">-&gt;</span></code>s and your <code class="lang-1c"><span class="hljs-string">|</span></code>s and your <code class="lang-gcode">{<span class="hljs-preprocessor">%</span> ... <span class="hljs-preprocessor">%</span>}</code>s. Future retinas will thank
+<p>Align your <code>-&gt;</code>s and your <code>|</code>s and your <code>{% ... %}</code>s. Future retinas will thank
 you.</p>
 <h3 id="parsing-an-established-language-cheat-">Parsing an established language? Cheat!</h3>
-<p class="lang-highlight">Almost all standards publish syntax guides with an accompanying diagram in
+<p>Almost all standards publish syntax guides with an accompanying diagram in
 (E)BNF. It’s worth it to Google around for this. With just a bit of common
-sense, you should be able to transliterate it to a <code class="lang-asciidoc"><span class="hljs-title">.ne</span></code> file.</p>
+sense, you should be able to transliterate it to a <code>.ne</code> file.</p>
 <hr>
 <p>Again, grammar-writing is largely about instinct and experience. The more you
 write, the more you’ll understand how it goes, and the faster you’ll be able to

--- a/docs/how-to-grammar-good.html
+++ b/docs/how-to-grammar-good.html
@@ -5,8 +5,6 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link href='https://fonts.googleapis.com/css?family=Roboto:300,700'
-              rel='stylesheet' type='text/css'/>
         <link rel="stylesheet" type="text/css" href="/www/main.css"/>
     </head>
     <body class="docs-page">
@@ -152,5 +150,20 @@ prototype and design.</p>
             <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
             <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
         </div>
+
+        <script>
+        WebFontConfig = {
+          google: {
+            families: ['Roboto:300,700']
+          }
+        };
+
+        (function(d) {
+          var wf = d.createElement('script'), s = d.scripts[0]
+          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
+          wf.async = true
+          s.parentNode.insertBefore(wf, s)
+        })(document)
+        </script>
     </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,8 +5,6 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link href='https://fonts.googleapis.com/css?family=Roboto:300,700'
-              rel='stylesheet' type='text/css'/>
         <link rel="stylesheet" type="text/css" href="/www/main.css"/>
     </head>
     <body class="docs-page">
@@ -413,5 +411,20 @@ learn more than you ever thought you wanted to know about parsing.</li>
             <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
             <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
         </div>
+
+        <script>
+        WebFontConfig = {
+          google: {
+            families: ['Roboto:300,700']
+          }
+        };
+
+        (function(d) {
+          var wf = d.createElement('script'), s = d.scripts[0]
+          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
+          wf.async = true
+          s.parentNode.insertBefore(wf, s)
+        })(document)
+        </script>
     </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,258 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link rel="stylesheet" type="text/css" href="/www/main.css"/>
+<style>
+body {
+    font-family: sans-serif;
+    font-weight: 300;
+    font-size: 15pt;
+    margin: 0px;
+    padding: 0px;
+    border-top: 0.1em #559 solid;
+    border-bottom: 0.1em #559 solid;
+}
+
+.wf-roboto-n3-active body {
+  font-family: Roboto, sans-serif;
+}
+
+#main a {
+    color: #55a;
+}
+#main a:visited {
+    color: #55a;
+}
+#main a:hover {
+    color: #259;
+}
+
+h1 {
+    font-size: 1.6em;
+    font-weight: 100;
+    letter-spacing: 0.5em;
+    text-align: center;
+    margin-top: 3em;
+    margin-bottom: 3em;
+}
+
+h1 a {
+    text-decoration: none;
+}
+
+h1:hover {
+    color: #559;
+    cursor: pointer;
+}
+
+#version {
+    background: orange;
+    border-radius: 50%;
+    font-weight: bold;
+    color: white;
+    width: 3.5em;
+    height: 3.5em;
+    display: inline-block;
+    text-align: center;
+    line-height: 3.5em;
+    letter-spacing: 0em;
+}
+
+h2 {
+    margin-top: 4em;
+}
+h3 {
+    margin-top: 3em;
+}
+h4 {
+    margin-top: 3em;
+}
+
+.center {
+    padding-left: 2em;
+    padding-right: 2em;
+    margin-left: auto;
+    margin-right: auto;
+}
+#main {
+    max-width: 35em;
+}
+
+#main p, ul, ol {
+    line-height: 1.5em;
+    margin-bottom: 1em;
+}
+
+#main li {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+#main ul li {
+    list-style: none;
+    min-width: 10em;
+}
+#main ul li:before {
+    display: inline-block;
+    content: &quot;\2014&quot;;
+    margin-left: -1.5em;
+    width: 1.5em;
+}
+
+#main textarea {
+    width: 100%;
+    height: 20em;
+    resize: none;
+    margin-top: 5px;
+    margin-bottom: 5px;
+
+    font-family: menlo, monaco, monospace;
+    font-size: 10pt;
+    padding: 5px;
+
+    border: none;
+    border-left: solid 1px #aaa;
+}
+#main textarea:focus {
+    outline: none;
+}
+
+#main img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 100%;
+}
+img + .caption {
+    text-align: center;
+    font-size: 0.7em;
+    color: #aaa;
+}
+
+/*
+#cy-viz {
+    width: 100%;
+}*/
+
+#footer {
+    margin-top: 10em;
+    color: #aaa;
+    font-size: 0.7em;
+    padding: 5em;
+}
+
+code {
+    margin-left: 0.2em;
+    margin-right: 0.2em;
+    padding: 0.2em;
+    border-radius: 0.2em;
+    background-color: #eee;
+}
+
+pre code {
+    border-radius: 0.5em;
+    //background-color: #559;
+    //color: white;
+    //text-shadow: 0em 0em 0.2em black;
+    padding: 0.5em;
+    display: block;
+    overflow: auto;
+}
+
+
+ol.tutorial {
+    counter-reset: tutorial-counter;
+}
+
+ol.tutorial li {
+    list-style: none;
+}
+
+ol.tutorial li:before {
+    content: counter(tutorial-counter);
+    counter-increment: tutorial-counter;
+
+    font-weight: bold;
+    border-radius: 50%;
+    background-color: #559;
+    width: 2em;
+    height: 2em;
+    display: inline-block;
+    text-align: center;
+    line-height: 2em;
+    color: white;
+
+    margin-left: -2em;
+
+    position: relative;
+    right: 1em;
+}
+
+input[type&#x3D;&quot;text&quot;] {
+    border: none;
+    font-family: monospace;
+    font-size: 1em;
+    color: #559;
+}
+
+input[type&#x3D;&quot;text&quot;]:focus {
+    outline: none;
+}
+
+
+nav {
+    border-right: 1px solid #aaa;
+    background: #fff;
+}
+nav ul {
+    padding: 0;
+    margin: 0;
+}
+nav a {
+    text-decoration: none;
+    color: #000;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0.25em 0.5em; */
+}
+.page {
+    display: block;
+    border-bottom: 1px solid #aaa;
+}
+
+.page-title-active {
+    background: #559;
+    color: #fff;
+}
+
+.page-heading {
+    display: block;
+    padding-left: 1em;
+}
+
+
+@media screen and (min-width: 36rem) {
+    nav {
+        position: fixed;
+        width: 16rem;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        white-space: nowrap;
+        overflow-y: auto;
+        font-size: 1rem;
+    }
+    body.docs-page {
+        margin-left: 16rem;
+    }
+}
+
+/* highlight.js */
+
+.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
+
+
+</style>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>

--- a/docs/index.html
+++ b/docs/index.html
@@ -257,6 +257,8 @@ nav a {
 
 
 </style>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -299,21 +301,21 @@ parses input strings.</p>
 <a href="https://docs.npmjs.com/getting-started/what-is-npm">NPM</a> package compatible
 with <a href="https://nodejs.org/en/">Node.js</a> and most browsers.</p>
 <p>To use the nearley <em>parser</em>, you need to install nearley <strong>locally</strong>.</p>
-<pre class="lang-highlight"><code class="lang-bash">$ npm install --save nearley
+<pre><code class="lang-bash">$ npm install --save nearley
 </code></pre>
 <p>To use the nearley <em>compiler</em>, you need to <em>additionally</em> install nearley
 <strong>globally</strong>.</p>
-<pre class="lang-highlight"><code class="lang-bash">$ npm install -g nearley
+<pre><code class="lang-bash">$ npm install -g nearley
 </code></pre>
-<p class="lang-highlight">This actually adds several new commands to your <code class="lang-xquery"><span class="hljs-variable">$PATH</span></code>:</p>
+<p>This actually adds several new commands to your <code>$PATH</code>:</p>
 <ul>
-<li class="lang-highlight"><code>nearleyc</code> compiles grammar files to JavaScript.</li>
-<li class="lang-highlight"><code class="lang-stata">nearley-<span class="hljs-keyword">test</span></code> lets you quickly test a grammar against some input and see the
+<li><code>nearleyc</code> compiles grammar files to JavaScript.</li>
+<li><code>nearley-test</code> lets you quickly test a grammar against some input and see the
 results. It also lets you explore the internal state of nearley’s Earley
 table, in case you find that interesting.</li>
-<li class="lang-highlight"><code>nearley-unparse</code> inverts a parser into a generator, allowing you to create
+<li><code>nearley-unparse</code> inverts a parser into a generator, allowing you to create
 random strings that match your grammar.</li>
-<li class="lang-highlight"><code>nearley-railroad</code> generates pretty railroad diagrams from your parser. This
+<li><code>nearley-railroad</code> generates pretty railroad diagrams from your parser. This
 is mainly helpful for creating documentation, as (for example) on json.org.</li>
 </ul>
 <p>These are documented on the <a href="tooling.html">tooling page</a>.</p>
@@ -326,320 +328,320 @@ exploring nearley grammars interactively.</p>
 <h2 id="getting-started-nearley-in-3-steps">Getting started: nearley in 3 steps</h2>
 <p>nearley was written with users in mind: getting started with nearley is as
 simple as:</p>
-<p class="lang-highlight"><strong>Step 1: Describe your grammar</strong> using the nearley syntax. In a file called
-<code class="lang-crmsh">grammar.<span class="hljs-operator">ne</span></code>, write:</p>
-<pre class="lang-highlight"><code class="lang-js">main -&gt; (statement <span class="hljs-string">"\n"</span>):+
-statement -&gt; <span class="hljs-string">"foo"</span> | <span class="hljs-string">"bar"</span>
+<p><strong>Step 1: Describe your grammar</strong> using the nearley syntax. In a file called
+<code>grammar.ne</code>, write:</p>
+<pre><code class="lang-js">main -&gt; (statement &quot;\n&quot;):+
+statement -&gt; &quot;foo&quot; | &quot;bar&quot;
 </code></pre>
 <p><strong>Step 2: Compile</strong> the grammar to a JavaScript module. On the command line,
 run:</p>
-<pre class="lang-highlight"><code class="lang-bash">$ nearleyc grammar.ne -o grammar.js
+<pre><code class="lang-bash">$ nearleyc grammar.ne -o grammar.js
 </code></pre>
 <p><strong>Step 3: Parse</strong> some data! In a new JavaScript file, write:</p>
-<pre class="lang-highlight"><code class="lang-js"><span class="hljs-keyword">const</span> nearley = <span class="hljs-built_in">require</span>(<span class="hljs-string">"nearley"</span>);
-<span class="hljs-keyword">const</span> grammar = <span class="hljs-built_in">require</span>(<span class="hljs-string">"./grammar.js"</span>);
+<pre><code class="lang-js">const nearley = require(&quot;nearley&quot;);
+const grammar = require(&quot;./grammar.js&quot;);
 
-<span class="hljs-comment">// Create a Parser object from our grammar.</span>
-<span class="hljs-keyword">const</span> parser = <span class="hljs-keyword">new</span> nearley.Parser(nearley.Grammar.fromCompiled(grammar));
+// Create a Parser object from our grammar.
+const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
 
-<span class="hljs-comment">// Parse something!</span>
-parser.feed(<span class="hljs-string">"foo\n"</span>);
+// Parse something!
+parser.feed(&quot;foo\n&quot;);
 
-<span class="hljs-comment">// parser.results is an array of possible parsings.</span>
-<span class="hljs-built_in">console</span>.log(parser.results); <span class="hljs-comment">// [[[[ "foo" ],"\n" ]]]</span>
+// parser.results is an array of possible parsings.
+console.log(parser.results); // [[[[ &quot;foo&quot; ],&quot;\n&quot; ]]]
 </code></pre>
 <h2 id="writing-a-parser-the-nearley-grammar-language">Writing a parser: the nearley grammar language</h2>
-<p class="lang-highlight">This section describes the nearley grammar language, in which you can describe
-grammars for nearley to parse. Grammars are conventionally kept in <code class="lang-asciidoc"><span class="hljs-title">.ne</span></code> files.
-You can then use <code>nearleyc</code> to compile your <code class="lang-asciidoc"><span class="hljs-title">.ne</span></code> grammars to JavaScript
+<p>This section describes the nearley grammar language, in which you can describe
+grammars for nearley to parse. Grammars are conventionally kept in <code>.ne</code> files.
+You can then use <code>nearleyc</code> to compile your <code>.ne</code> grammars to JavaScript
 modules.</p>
-<p class="lang-highlight">You can find many examples of nearley grammars online, as well as some in the
+<p>You can find many examples of nearley grammars online, as well as some in the
 <code>examples/</code> directory of the <a href="http://github.com/Hardmath123/nearley">Github
 repository</a>.</p>
 <h3 id="vocabulary">Vocabulary</h3>
 <ul>
-<li class="lang-highlight">A <em>terminal</em> is a single, constant string or a token. For example, the
-keyword <code class="lang-1c"><span class="hljs-string">"if"</span></code> is a terminal.</li>
+<li>A <em>terminal</em> is a single, constant string or a token. For example, the
+keyword <code>&quot;if&quot;</code> is a terminal.</li>
 <li>A <em>nonterminal</em> describes a set of possible strings. For example, all “if”
 statements can be described by a single nonterminal whose value depends on
 the condition and body of the if statement.</li>
-<li class="lang-highlight">A <em>rule</em> (or production rule) is a definition of a nonterminal. For example,<pre class="lang-highlight"><code class="lang-js">ifStatement -&gt; <span class="hljs-string">"if"</span> condition <span class="hljs-string">"then"</span> statement <span class="hljs-string">"endif"</span>
+<li>A <em>rule</em> (or production rule) is a definition of a nonterminal. For example,<pre><code class="lang-js">ifStatement -&gt; &quot;if&quot; condition &quot;then&quot; statement &quot;endif&quot;
 </code></pre>
-is the rule according to which the if statement nonterminal, <code class="lang-bash"><span class="hljs-keyword">if</span>Statement</code>,
-is parsed. It depends on the nonterminals <code class="lang-mel"><span class="hljs-keyword">condition</span></code> and <code>statement</code>. A
+is the rule according to which the if statement nonterminal, <code>ifStatement</code>,
+is parsed. It depends on the nonterminals <code>condition</code> and <code>statement</code>. A
 nonterminal can be described by multiple rules. For example, we can add a
-second rule<pre class="lang-highlight"><code class="lang-js">ifStatement -&gt; <span class="hljs-string">"if"</span> condition <span class="hljs-string">"then"</span> statement <span class="hljs-string">"else"</span> statement <span class="hljs-string">"endif"</span>
+second rule<pre><code class="lang-js">ifStatement -&gt; &quot;if&quot; condition &quot;then&quot; statement &quot;else&quot; statement &quot;endif&quot;
 </code></pre>
 to support “else” clauses.</li>
 </ul>
-<p class="lang-highlight">By default, nearley attempts to parse the first nonterminal defined in the
+<p>By default, nearley attempts to parse the first nonterminal defined in the
 grammar. In the following grammar, nearley will try to parse input text as an
-<code class="lang-mel"><span class="hljs-keyword">expression</span></code>.</p>
-<pre class="lang-highlight"><code class="lang-js">expression -&gt; number <span class="hljs-string">"+"</span> number
-expression -&gt; number <span class="hljs-string">"-"</span> number
-expression -&gt; number <span class="hljs-string">"*"</span> number
-expression -&gt; number <span class="hljs-string">"/"</span> number
-number -&gt; [<span class="hljs-number">0</span>-<span class="hljs-number">9</span>]:+
+<code>expression</code>.</p>
+<pre><code class="lang-js">expression -&gt; number &quot;+&quot; number
+expression -&gt; number &quot;-&quot; number
+expression -&gt; number &quot;*&quot; number
+expression -&gt; number &quot;/&quot; number
+number -&gt; [0-9]:+
 </code></pre>
-<p class="lang-highlight">You can use the pipe character <code class="lang-1c"><span class="hljs-string">|</span></code> to separate alternative rules for a
-nonterminal. In the example below, <code class="lang-mel"><span class="hljs-keyword">expression</span></code> has four different rules.</p>
-<pre class="lang-highlight"><code class="lang-js">expression -&gt;
-      number <span class="hljs-string">"+"</span> number
-    | number <span class="hljs-string">"-"</span> number
-    | number <span class="hljs-string">"*"</span> number
-    | number <span class="hljs-string">"/"</span> number
+<p>You can use the pipe character <code>|</code> to separate alternative rules for a
+nonterminal. In the example below, <code>expression</code> has four different rules.</p>
+<pre><code class="lang-js">expression -&gt;
+      number &quot;+&quot; number
+    | number &quot;-&quot; number
+    | number &quot;*&quot; number
+    | number &quot;/&quot; number
 </code></pre>
-<p class="lang-highlight">The keyword <code class="lang-actionscript"><span class="hljs-literal">null</span></code> stands for the <strong>epsilon rule</strong>, which matches nothing. The
+<p>The keyword <code>null</code> stands for the <strong>epsilon rule</strong>, which matches nothing. The
 following nonterminal matches zero or more <code>cow</code>s in a row, such as
 <code>cowcowcow</code>:</p>
-<pre class="lang-highlight"><code class="lang-js">a -&gt; <span class="hljs-literal">null</span> | a <span class="hljs-string">"cow"</span>
+<pre><code class="lang-js">a -&gt; null | a &quot;cow&quot;
 </code></pre>
 <h3 id="postprocessors">Postprocessors</h3>
-<p class="lang-highlight">By default, nearley wraps everything matched by a rule into an array. For
-example, when <code class="lang-crmsh"><span class="hljs-keyword">rule</span> -&gt; <span class="hljs-string">"foo"</span> <span class="hljs-string">"bar"</span></code> matches, it creates the “parse tree”
-<code class="lang-json">[<span class="hljs-string">"foo"</span>, <span class="hljs-string">"bar"</span>]</code>.  Most of the time, however, you need to process that data in
+<p>By default, nearley wraps everything matched by a rule into an array. For
+example, when <code>rule -&gt; &quot;foo&quot; &quot;bar&quot;</code> matches, it creates the “parse tree”
+<code>[&quot;foo&quot;, &quot;bar&quot;]</code>.  Most of the time, however, you need to process that data in
 some way: for example, you may want to filter out whitespace, or transform the
 results into a custom JavaScript object.</p>
-<p class="lang-highlight">For this purpose, each rule can have a <em>postprocessor</em>: a JavaScript function
+<p>For this purpose, each rule can have a <em>postprocessor</em>: a JavaScript function
 that transforms the array and returns a “processed” version of the result.
-Postprocessors are wrapped in <code class="lang-gcode">{<span class="hljs-preprocessor">%</span> <span class="hljs-preprocessor">%</span>}</code>:</p>
-<pre class="lang-highlight"><code class="lang-js">expression -&gt; number <span class="hljs-string">"+"</span> number {%
-    <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">data, location, reject</span>) </span>{
-        <span class="hljs-keyword">return</span> {
-            operator: <span class="hljs-string">"sum"</span>,
-            leftOperand: data[<span class="hljs-number">0</span>],
-            rightOperand: data[<span class="hljs-number">2</span>] <span class="hljs-comment">// data[1] is "+"</span>
+Postprocessors are wrapped in <code>{% %}</code>:</p>
+<pre><code class="lang-js">expression -&gt; number &quot;+&quot; number {%
+    function(data, location, reject) {
+        return {
+            operator: &quot;sum&quot;,
+            leftOperand: data[0],
+            rightOperand: data[2] // data[1] is &quot;+&quot;
         };
     }
 %}
 </code></pre>
-<p class="lang-highlight">The rule above will parse the string <code class="lang-cpp"><span class="hljs-number">5</span>+<span class="hljs-number">10</span></code> into <code class="lang-css"><span class="hljs-rules">{ <span class="hljs-rule"><span class="hljs-attribute">operator</span>:<span class="hljs-value"> <span class="hljs-string">"sum"</span>,
-leftOperand: <span class="hljs-string">"5"</span>, rightOperand: <span class="hljs-string">"10"</span> </span></span></span>}</code>.</p>
+<p>The rule above will parse the string <code>5+10</code> into <code>{ operator: &quot;sum&quot;,
+leftOperand: &quot;5&quot;, rightOperand: &quot;10&quot; }</code>.</p>
 <p>The postprocessor can be any function. It will be passed three arguments:</p>
 <ul>
-<li class="lang-highlight"><code class="lang-haskell"><span class="hljs-typedef"><span class="hljs-keyword">data</span>: <span class="hljs-type">Array</span></span></code> - an array that contains the results of parsing each part of
+<li><code>data: Array</code> - an array that contains the results of parsing each part of
 the rule. Note that it is still an array, even if the rule only has one part!
-You can use the built-in <code class="lang-gcode">{<span class="hljs-preprocessor">%</span> id <span class="hljs-preprocessor">%</span>}</code> postprocessor to convert a one-item array
+You can use the built-in <code>{% id %}</code> postprocessor to convert a one-item array
 into the item itself.</li>
-<li class="lang-highlight"><code class="lang-http"><span class="hljs-attribute">location</span>: <span class="hljs-string">number</span></code> - the index (zero-based) at which the rule match starts.
+<li><code>location: number</code> - the index (zero-based) at which the rule match starts.
 This is useful, for example, to construct an error message that tells you where
 in the source the error occurred.</li>
-<li class="lang-highlight"><code class="lang-http"><span class="hljs-attribute">reject</span>: <span class="hljs-string">Object</span></code> - return this object to signal that this rule doesn’t
+<li><code>reject: Object</code> - return this object to signal that this rule doesn’t
 <em>actually</em> match. This is necessary in certain edge-conditions. For example,
 suppose you want sequences of letters to match variables, except for the
-keyword <code class="lang-actionscript"><span class="hljs-keyword">var</span></code>. In this case, your rule may be<pre class="lang-highlight"><code class="lang-js">word -&gt; [a-z]:+ {%
-    <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">d,l, reject</span>) </span>{
-        <span class="hljs-keyword">if</span> (d[<span class="hljs-number">0</span>] == <span class="hljs-string">'var'</span>) {
-            <span class="hljs-keyword">return</span> reject;
-        } <span class="hljs-keyword">else</span> {
-            <span class="hljs-keyword">return</span> {<span class="hljs-string">'var'</span>: d[<span class="hljs-number">0</span>]};
+keyword <code>var</code>. In this case, your rule may be<pre><code class="lang-js">word -&gt; [a-z]:+ {%
+    function(d,l, reject) {
+        if (d[0] == &#39;var&#39;) {
+            return reject;
+        } else {
+            return {&#39;var&#39;: d[0]};
         }
     }
 %}
 </code></pre>
-Please note that grammars using <code class="lang-vhdl"><span class="hljs-keyword">reject</span></code> are not context-free, and are often
+Please note that grammars using <code>reject</code> are not context-free, and are often
 much slower to parse. Use it wisely! You can usually avoid the need for
-<code class="lang-vhdl"><span class="hljs-keyword">reject</span></code> by using a <a href="#tokenizers">tokenizer</a>.</li>
+<code>reject</code> by using a <a href="#tokenizers">tokenizer</a>.</li>
 </ul>
 <p>Remember that a postprocessor is scoped to a single rule, not the whole
 nonterminal. If a nonterminal has multiple alternative rules, each of them can
 have its own postprocessor.</p>
-<p class="lang-highlight">For arrow-function users, a convenient pattern is to decompose the <code class="lang-haskell"><span class="hljs-typedef"><span class="hljs-keyword">data</span></span></code> array
+<p>For arrow-function users, a convenient pattern is to decompose the <code>data</code> array
 within the argument of the arrow function:</p>
-<pre class="lang-highlight"><code class="lang-js">expression -&gt;
-      number <span class="hljs-string">"+"</span> number {% ([first, _, second]) =&gt; first + second %}
-    | number <span class="hljs-string">"-"</span> number {% ([first, _, second]) =&gt; first - second %}
-    | number <span class="hljs-string">"*"</span> number {% ([first, _, second]) =&gt; first * second %}
-    | number <span class="hljs-string">"/"</span> number {% ([first, _, second]) =&gt; first / second %}
+<pre><code class="lang-js">expression -&gt;
+      number &quot;+&quot; number {% ([first, _, second]) =&gt; first + second %}
+    | number &quot;-&quot; number {% ([first, _, second]) =&gt; first - second %}
+    | number &quot;*&quot; number {% ([first, _, second]) =&gt; first * second %}
+    | number &quot;/&quot; number {% ([first, _, second]) =&gt; first / second %}
 </code></pre>
 <p>There are two built-in postprocessors for the most common scenarios:</p>
 <ul>
-<li class="lang-highlight"><code class="lang-applescript"><span class="hljs-property">id</span></code> - returns the first element of the <code class="lang-haskell"><span class="hljs-typedef"><span class="hljs-keyword">data</span></span></code> array. This is useful to
-extract the content of a single-element array: <code class="lang-erlang-repl"><span class="hljs-function_or_atom">foo</span> <span class="hljs-arrow">-&gt;</span> <span class="hljs-function_or_atom">bar</span> {<span class="hljs-comment">% id %}</span></code></li>
-<li class="lang-highlight"><code>nuller</code> - returns null. This is useful for whitespace rules: <code class="lang-erlang-repl"><span class="hljs-function_or_atom">space</span> <span class="hljs-arrow">-&gt;</span> <span class="hljs-string">" "</span>
-{<span class="hljs-comment">% nuller %}</span></code></li>
+<li><code>id</code> - returns the first element of the <code>data</code> array. This is useful to
+extract the content of a single-element array: <code>foo -&gt; bar {% id %}</code></li>
+<li><code>nuller</code> - returns null. This is useful for whitespace rules: <code>space -&gt; &quot; &quot;
+{% nuller %}</code></li>
 </ul>
 <h4 id="target-languages">Target languages</h4>
-<p class="lang-highlight">By default, <code>nearleyc</code> compiles your grammar to JavaScript. You can also choose
-CoffeeScript or TypeScript by adding <code class="lang-aspectj"><span class="hljs-annotation">@preprocessor</span> coffee</code> or <code class="lang-aspectj"><span class="hljs-annotation">@preprocessor</span>
+<p>By default, <code>nearleyc</code> compiles your grammar to JavaScript. You can also choose
+CoffeeScript or TypeScript by adding <code>@preprocessor coffee</code> or <code>@preprocessor
 typescript</code> at the top of your grammar file. This can be useful to write your
 postprocessors in a different language, and to get type annotations if you wish
 to use nearley in a statically typed dialect of JavaScript.</p>
 <h3 id="more-syntax-tips-and-tricks">More syntax: tips and tricks</h3>
 <h4 id="comments">Comments</h4>
-<p class="lang-highlight">Comments are marked with ‘#’. Everything from <code class="lang-vala"><span class="hljs-preprocessor">#</span></code> to the end of a line is
+<p>Comments are marked with ‘#’. Everything from <code>#</code> to the end of a line is
 ignored:</p>
-<pre class="lang-highlight"><code class="lang-ini">expression -&gt; number "+" number <span class="hljs-comment"># sum of two numbers</span>
+<pre><code class="lang-ini">expression -&gt; number &quot;+&quot; number # sum of two numbers
 </code></pre>
 <h4 id="charsets">Charsets</h4>
 <p>You can use valid RegExp charsets in a rule (unless you’re using a
 <a href="#tokenizers">tokenizer</a>):</p>
-<pre class="lang-highlight"><code class="lang-autohotkey">not_<span class="hljs-built_in">a_letter</span> -&gt; [^<span class="hljs-literal">a</span>-zA-Z]
-</code></pre><p class="lang-highlight">The <code class="lang-erlang">.</code> character can be used to represent any character.</p>
+<pre><code>not_a_letter -&gt; [^a-zA-Z]
+</code></pre><p>The <code>.</code> character can be used to represent any character.</p>
 <h4 id="case-insensitive-string-literals">Case-insensitive string literals</h4>
-<p class="lang-highlight">You can create case-insensitive string literals by adding an <code class="lang-matlab"><span class="hljs-built_in">i</span></code> after the
+<p>You can create case-insensitive string literals by adding an <code>i</code> after the
 string literal:</p>
-<pre class="lang-highlight"><code class="lang-elixir">cow -&gt; <span class="hljs-string">"cow"</span>i <span class="hljs-comment"># matches CoW, COW, and so on.</span>
-</code></pre><p class="lang-highlight">Note that if you are using a lexer, your lexer should use the <code class="lang-matlab"><span class="hljs-built_in">i</span></code> flag in its
+<pre><code>cow -&gt; &quot;cow&quot;i # matches CoW, COW, and so on.
+</code></pre><p>Note that if you are using a lexer, your lexer should use the <code>i</code> flag in its
 regexes instead. That is, if you are using a lexer, you should <em>not</em> use the
-<code class="lang-matlab"><span class="hljs-built_in">i</span></code> suffix in nearley.</p>
+<code>i</code> suffix in nearley.</p>
 <h4 id="ebnf">EBNF</h4>
-<p class="lang-highlight">nearley supports the <code class="lang-gherkin"><span class="hljs-keyword">*</span></code>, <code>?</code>, and <code class="lang-diff"><span class="hljs-addition">+</span></code> operators from
+<p>nearley supports the <code>*</code>, <code>?</code>, and <code>+</code> operators from
 <a href="https://en.wikipedia.org/wiki/Extended_Backus–Naur_form">EBNF</a> as shown:</p>
-<pre class="lang-highlight"><code class="lang-ini">batman -&gt; "na":* "batman" <span class="hljs-comment"># nananana...nanabatman</span>
+<pre><code class="lang-ini">batman -&gt; &quot;na&quot;:* &quot;batman&quot; # nananana...nanabatman
 </code></pre>
 <p>You can also use capture groups with parentheses. Its contents can be anything
 that a rule can have:</p>
-<pre class="lang-highlight"><code class="lang-js">banana -&gt; <span class="hljs-string">"ba"</span> (<span class="hljs-string">"na"</span> {% id %} | <span class="hljs-string">"NA"</span> {% id %}):+
+<pre><code class="lang-js">banana -&gt; &quot;ba&quot; (&quot;na&quot; {% id %} | &quot;NA&quot; {% id %}):+
 </code></pre>
 <h3 id="macros">Macros</h3>
 <p>Macros allow you to create polymorphic rules:</p>
-<pre class="lang-highlight"><code class="lang-ini"><span class="hljs-comment"># Matches "'Hello?' 'Hello?' 'Hello?'"</span>
-main -&gt; matchThree<span class="hljs-title">[inQuotes["Hello?"]]</span>
+<pre><code class="lang-ini"># Matches &quot;&#39;Hello?&#39; &#39;Hello?&#39; &#39;Hello?&#39;&quot;
+main -&gt; matchThree[inQuotes[&quot;Hello?&quot;]]
 
-matchThree<span class="hljs-title">[X]</span> -&gt; $X " " $X " " $X
+matchThree[X] -&gt; $X &quot; &quot; $X &quot; &quot; $X
 
-inQuotes<span class="hljs-title">[X]</span> -&gt; "'" $X "'"
+inQuotes[X] -&gt; &quot;&#39;&quot; $X &quot;&#39;&quot;
 </code></pre>
 <p>Macros are dynamically scoped, which means they see arguments passed to parent
 macros:</p>
-<pre class="lang-highlight"><code class="lang-ini"><span class="hljs-comment"># Matches "Cows oink." and "Cows moo!"</span>
-main -&gt; sentence<span class="hljs-title">["Cows", ("." | "!")]</span>
+<pre><code class="lang-ini"># Matches &quot;Cows oink.&quot; and &quot;Cows moo!&quot;
+main -&gt; sentence[&quot;Cows&quot;, (&quot;.&quot; | &quot;!&quot;)]
 
-sentence<span class="hljs-title">[ANIMAL, PUNCTUATION]</span> -&gt; animalGoes<span class="hljs-title">[("moo" | "oink" | "baa")]</span> $PUNCTUATION
+sentence[ANIMAL, PUNCTUATION] -&gt; animalGoes[(&quot;moo&quot; | &quot;oink&quot; | &quot;baa&quot;)] $PUNCTUATION
 
-animalGoes<span class="hljs-title">[SOUND]</span> -&gt; $ANIMAL " " $SOUND <span class="hljs-comment"># uses $ANIMAL from its caller</span>
+animalGoes[SOUND] -&gt; $ANIMAL &quot; &quot; $SOUND # uses $ANIMAL from its caller
 </code></pre>
-<p class="lang-highlight">Macros are expanded at compile time and inserted in places they are used. They
+<p>Macros are expanded at compile time and inserted in places they are used. They
 are not “real” rules. Therefore, macros <em>cannot</em> be recursive (<code>nearleyc</code> will
 go into an infinite loop trying to expand the macro-loop).</p>
 <h3 id="additional-js">Additional JS</h3>
-<p class="lang-highlight">For more intricate postprocessors, or any other functionality you may need, you
+<p>For more intricate postprocessors, or any other functionality you may need, you
 can include chunks of JavaScript code between production rules by surrounding
-it with <code class="lang-gcode">@{<span class="hljs-preprocessor">%</span> ... <span class="hljs-preprocessor">%</span>}</code>:</p>
-<pre class="lang-highlight"><code class="lang-js">@{%
-<span class="hljs-keyword">const</span> cowSays = <span class="hljs-built_in">require</span>(<span class="hljs-string">"./cow.js"</span>);
+it with <code>@{% ... %}</code>:</p>
+<pre><code class="lang-js">@{%
+const cowSays = require(&quot;./cow.js&quot;);
 %}
 
-cow -&gt; <span class="hljs-string">"moo"</span> {% ([moo]) =&gt; cowSays(moo) %}
+cow -&gt; &quot;moo&quot; {% ([moo]) =&gt; cowSays(moo) %}
 </code></pre>
 <p>Note that it doesn’t matter where you add these; they all get hoisted to the
 top of the generated code.</p>
 <h3 id="importing-other-grammars">Importing other grammars</h3>
 <p>You can include the content of other grammar files:</p>
-<pre class="lang-highlight"><code class="lang-ini">@include "../misc/primitives.ne" <span class="hljs-comment"># path relative to file being compiled</span>
-sum -&gt; number "+" number <span class="hljs-comment"># uses "number" from the included file</span>
+<pre><code class="lang-ini">@include &quot;../misc/primitives.ne&quot; # path relative to file being compiled
+sum -&gt; number &quot;+&quot; number # uses &quot;number&quot; from the included file
 </code></pre>
 <p>There are several builtin helper files that you can include:</p>
-<pre class="lang-highlight"><code class="lang-ini">@builtin "cow.ne"
+<pre><code class="lang-ini">@builtin &quot;cow.ne&quot;
 main -&gt; cow:+
 </code></pre>
-<p>See the <a href="builtin" class="lang-highlight"><code class="lang-bash"><span class="hljs-built_in">builtin</span>/</code></a> directory for more details. Contributions are
+<p>See the <a href="builtin"><code>builtin/</code></a> directory for more details. Contributions are
 welcome!</p>
 <p>Including a file imports <em>all</em> of the nonterminals defined in it, as well as
 any JS, macros, and configuration options defined there.</p>
 <h2 id="using-a-parser-the-nearley-api">Using a parser: the nearley API</h2>
-<p class="lang-highlight">Once you have compiled a <code class="lang-crmsh">grammar.<span class="hljs-operator">ne</span></code> file to a <code class="lang-css"><span class="hljs-tag">grammar</span><span class="hljs-class">.js</span></code> module, you can
+<p>Once you have compiled a <code>grammar.ne</code> file to a <code>grammar.js</code> module, you can
 then use nearley to instantiate a <code>Parser</code> object.</p>
 <p>First, import nearley and your grammar.</p>
-<pre class="lang-highlight"><code class="lang-js"><span class="hljs-keyword">const</span> nearley = <span class="hljs-built_in">require</span>(<span class="hljs-string">"nearley"</span>);
-<span class="hljs-keyword">const</span> grammar = <span class="hljs-built_in">require</span>(<span class="hljs-string">"./grammar.js"</span>);
+<pre><code class="lang-js">const nearley = require(&quot;nearley&quot;);
+const grammar = require(&quot;./grammar.js&quot;);
 </code></pre>
-<p class="lang-highlight">Note that if you are parsing in the browser, you can simply include
-<code class="lang-css"><span class="hljs-tag">nearley</span><span class="hljs-class">.js</span></code> and <code class="lang-css"><span class="hljs-tag">grammar</span><span class="hljs-class">.js</span></code> in <code class="lang-xml"><span class="hljs-tag">&lt;<span class="hljs-title">script</span>&gt;</span><span class="undefined"></span></code> tags.</p>
-<p class="lang-highlight">Next, use the grammar to create a new <code class="lang-css"><span class="hljs-tag">nearley</span><span class="hljs-class">.Parser</span></code> object.</p>
-<pre class="lang-highlight"><code class="lang-js"><span class="hljs-comment">// Create a Parser object from our grammar.</span>
-<span class="hljs-keyword">const</span> parser = <span class="hljs-keyword">new</span> nearley.Parser(nearley.Grammar.fromCompiled(grammar));
+<p>Note that if you are parsing in the browser, you can simply include
+<code>nearley.js</code> and <code>grammar.js</code> in <code>&lt;script&gt;</code> tags.</p>
+<p>Next, use the grammar to create a new <code>nearley.Parser</code> object.</p>
+<pre><code class="lang-js">// Create a Parser object from our grammar.
+const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
 </code></pre>
-<p class="lang-highlight">Once you have a <code>Parser</code>, you can <code class="lang-asciidoc"><span class="hljs-title">.feed</span></code> it a string to parse. Since nearley
+<p>Once you have a <code>Parser</code>, you can <code>.feed</code> it a string to parse. Since nearley
 is a <em>streaming</em> parser, you can feed strings more than once. For example, a
 REPL might feed the parser lines of code as the user enters them:</p>
-<pre class="lang-highlight"><code class="lang-js"><span class="hljs-comment">// Parse something!</span>
-parser.feed(<span class="hljs-string">"if (true) {"</span>);
-parser.feed(<span class="hljs-string">"x = 1"</span>);
-parser.feed(<span class="hljs-string">"}"</span>);
-<span class="hljs-comment">// or, parser.feed("if (true) {x=1}");</span>
+<pre><code class="lang-js">// Parse something!
+parser.feed(&quot;if (true) {&quot;);
+parser.feed(&quot;x = 1&quot;);
+parser.feed(&quot;}&quot;);
+// or, parser.feed(&quot;if (true) {x=1}&quot;);
 </code></pre>
-<p class="lang-highlight">Finally, you can query the <code class="lang-asciidoc"><span class="hljs-title">.results</span></code> property of the parser.</p>
-<pre class="lang-highlight"><code class="lang-js"><span class="hljs-comment">// parser.results is an array of possible parsings.</span>
-<span class="hljs-built_in">console</span>.log(parser.results);
-<span class="hljs-comment">// [{'type': 'if', 'condition': ..., 'body': ...}]</span>
+<p>Finally, you can query the <code>.results</code> property of the parser.</p>
+<pre><code class="lang-js">// parser.results is an array of possible parsings.
+console.log(parser.results);
+// [{&#39;type&#39;: &#39;if&#39;, &#39;condition&#39;: ..., &#39;body&#39;: ...}]
 </code></pre>
 <h3 id="a-note-on-ambiguity">A note on ambiguity</h3>
-<p class="lang-highlight">Why is <code class="lang-css"><span class="hljs-tag">parser</span><span class="hljs-class">.results</span></code> an array? Sometimes, a grammar can parse a particular
+<p>Why is <code>parser.results</code> an array? Sometimes, a grammar can parse a particular
 string in multiple different ways. For example, the following grammar parses
-the string <code class="lang-1c"><span class="hljs-string">"xyz"</span></code> in two different ways.</p>
-<pre class="lang-highlight"><code class="lang-js">x -&gt; <span class="hljs-string">"xy"</span> <span class="hljs-string">"z"</span>
-   | <span class="hljs-string">"x"</span> <span class="hljs-string">"yz"</span>
+the string <code>&quot;xyz&quot;</code> in two different ways.</p>
+<pre><code class="lang-js">x -&gt; &quot;xy&quot; &quot;z&quot;
+   | &quot;x&quot; &quot;yz&quot;
 </code></pre>
-<p class="lang-highlight">Such grammars are <em>ambiguous</em>. nearley provides you with <em>all</em> the parsings. In
+<p>Such grammars are <em>ambiguous</em>. nearley provides you with <em>all</em> the parsings. In
 most cases, however, your grammars should not be ambiguous (parsing ambiguous
 grammars is inefficient!). Thus, the most common usage is to simply query
-<code class="lang-css"><span class="hljs-tag">parser</span><span class="hljs-class">.results</span><span class="hljs-attr_selector">[0]</span></code>.</p>
+<code>parser.results[0]</code>.</p>
 <h3 id="catching-errors">Catching errors</h3>
 <p>nearley is a <em>streaming</em> parser: you can keep feeding it more strings. This
 means that there are two error scenarios in nearley.</p>
 <p>Consider the simple parser below for the examples to follow.</p>
-<pre class="lang-highlight"><code class="lang-js">main -&gt; <span class="hljs-string">"Cow goes moo."</span> {% <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">d</span>) </span>{<span class="hljs-keyword">return</span> <span class="hljs-string">"yay!"</span>; } %}
+<pre><code class="lang-js">main -&gt; &quot;Cow goes moo.&quot; {% function(d) {return &quot;yay!&quot;; } %}
 </code></pre>
-<p class="lang-highlight">If there are no possible parsings given the current input, but in the <em>future</em>
+<p>If there are no possible parsings given the current input, but in the <em>future</em>
 there <em>might</em> be results if you feed it more strings, then nearley will
-temporarily set the <code>results</code> array to the empty array, <code class="lang-json">[]</code>.</p>
-<pre class="lang-highlight"><code class="lang-js">parser.feed(<span class="hljs-string">"Cow "</span>);  <span class="hljs-comment">// parser.results is []</span>
-parser.feed(<span class="hljs-string">"goes "</span>); <span class="hljs-comment">// parser.results is []</span>
-parser.feed(<span class="hljs-string">"moo."</span>);  <span class="hljs-comment">// parser.results is ["yay!"]</span>
+temporarily set the <code>results</code> array to the empty array, <code>[]</code>.</p>
+<pre><code class="lang-js">parser.feed(&quot;Cow &quot;);  // parser.results is []
+parser.feed(&quot;goes &quot;); // parser.results is []
+parser.feed(&quot;moo.&quot;);  // parser.results is [&quot;yay!&quot;]
 </code></pre>
-<p class="lang-highlight">If there are no possible parsings, and there is no way to “recover” by feeding
-more data, then nearley will throw an error whose <code class="lang-applescript"><span class="hljs-command">offset</span></code> property is the
+<p>If there are no possible parsings, and there is no way to “recover” by feeding
+more data, then nearley will throw an error whose <code>offset</code> property is the
 index of the offending token.</p>
-<pre class="lang-highlight"><code class="lang-js"><span class="hljs-keyword">try</span> {
-    parser.feed(<span class="hljs-string">"Cow goes% moo."</span>);
-} <span class="hljs-keyword">catch</span>(parseError) {
-    <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"Error at character "</span> + parseError.offset); <span class="hljs-comment">// "Error at character 9"</span>
+<pre><code class="lang-js">try {
+    parser.feed(&quot;Cow goes% moo.&quot;);
+} catch(parseError) {
+    console.log(&quot;Error at character &quot; + parseError.offset); // &quot;Error at character 9&quot;
 }
 </code></pre>
 <h3 id="tokenizers">Tokenizers</h3>
 <p>By default, nearley splits the input into a stream of characters. This is
 called <em>scannerless</em> parsing.</p>
-<p class="lang-highlight">A tokenizer splits the input into a stream of larger units called <em>tokens</em>.
+<p>A tokenizer splits the input into a stream of larger units called <em>tokens</em>.
 This happens in a separate stage before parsing. For example, a tokenizer might
-convert <code class="lang-cpp"><span class="hljs-number">512</span> + <span class="hljs-number">10</span></code> into <code class="lang-json">[<span class="hljs-string">"512"</span>, <span class="hljs-string">"+"</span>, <span class="hljs-string">"10"</span>]</code>: notice how it removed the
+convert <code>512 + 10</code> into <code>[&quot;512&quot;, &quot;+&quot;, &quot;10&quot;]</code>: notice how it removed the
 whitespace, and combined multi-digit numbers into a single number.</p>
 <p>Using a tokenizer has many benefits. It…</p>
 <ul>
 <li>…often makes your parser faster by more than an order of magnitude.</li>
 <li>…allows you to write cleaner, more maintainable grammars.</li>
-<li class="lang-highlight">…helps avoid ambiguous grammars in some cases. For example, a tokenizer can
+<li>…helps avoid ambiguous grammars in some cases. For example, a tokenizer can
 easily tell you that <code>superclass</code> is a single keyword, not a sequence of
-<code class="lang-actionscript"><span class="hljs-keyword">super</span></code> and <code class="lang-coffeescript"><span class="hljs-class"><span class="hljs-keyword">class</span></span></code> keywords.</li>
+<code>super</code> and <code>class</code> keywords.</li>
 <li>…gives you <em>lexical information</em> such as line numbers for each token. This
 lets you make better error messages.</li>
 </ul>
 <p>nearley supports and recommends <a href="https://github.com/tjvr/moo">Moo</a>, a
 super-fast tokenizer. Here is a simple example:</p>
-<pre class="lang-highlight"><code class="lang-coffeescript">@{%
-const moo = <span class="hljs-built_in">require</span>(<span class="hljs-string">"moo"</span>);
+<pre><code class="lang-coffeescript">@{%
+const moo = require(&quot;moo&quot;);
 
 const lexer = moo.compile({
-  <span class="hljs-attribute">ws</span>:     <span class="hljs-regexp">/[ \t]+/</span>,
-  <span class="hljs-attribute">number</span>: <span class="hljs-regexp">/[0-9]+/</span>,
-  <span class="hljs-attribute">times</span>:  <span class="hljs-regexp">/\*|x/</span>
+  ws:     /[ \t]+/,
+  number: /[0-9]+/,
+  times:  /\*|x/
 });
 %}
 
-<span class="hljs-comment"># Pass your lexer object using the @lexer option:</span>
-<span class="hljs-property">@lexer</span> lexer
+# Pass your lexer object using the @lexer option:
+@lexer lexer
 
-<span class="hljs-comment"># Use %token to match any token of that type instead of "token":</span>
+# Use %token to match any token of that type instead of &quot;token&quot;:
 multiplication -&gt; %number %ws %times %ws %number {% ([first, , , , second]) =&gt; first * second %}
 </code></pre>
 <p>Have a look at <a href="https://github.com/tjvr/moo#usage">the Moo documentation</a> to
 learn more about the tokenizer.</p>
 <p>Note that when using a tokenizer, raw strings match full tokens parsed by Moo.
 This is convenient for matching keywords.</p>
-<pre class="lang-highlight"><code class="lang-ini">ifStatement -&gt; "if" condition "then" block
+<pre><code class="lang-ini">ifStatement -&gt; &quot;if&quot; condition &quot;then&quot; block
 </code></pre>
-<p class="lang-highlight">You use the parser as usual: call <code class="lang-stylus">parser.<span class="hljs-function"><span class="hljs-title">feed</span><span class="hljs-params">(data)</span></span></code>, and nearley will give
+<p>You use the parser as usual: call <code>parser.feed(data)</code>, and nearley will give
 you the parsed results in return.</p>
 <h3 id="further-reading">Further reading</h3>
 <ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -257,8 +257,6 @@ nav a {
 
 
 </style>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -671,13 +669,13 @@ learn more than you ever thought you wanted to know about parsing.</li>
             families: ['Roboto:300,700']
           }
         };
-
-        (function(d) {
-          var wf = d.createElement('script'), s = d.scripts[0]
-          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
-          wf.async = true
-          s.parentNode.insertBefore(wf, s)
-        })(document)
+        </script>
+        <script async src="//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js"></script>
+        <script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>
+        document.querySelector('#highlight-js').addEventListener('load', function() {
+          hljs.initHighlightingOnLoad();
+        })
         </script>
     </body>
 </html>

--- a/docs/layouts/template.html
+++ b/docs/layouts/template.html
@@ -8,6 +8,8 @@
 <style>
 {{css}}
 </style>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body{{#if isDoc}} class="docs-page"{{/if}}>
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>

--- a/docs/layouts/template.html
+++ b/docs/layouts/template.html
@@ -5,7 +5,9 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link rel="stylesheet" type="text/css" href="/www/main.css"/>
+<style>
+{{css}}
+</style>
     </head>
     <body{{#if isDoc}} class="docs-page"{{/if}}>
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>

--- a/docs/layouts/template.html
+++ b/docs/layouts/template.html
@@ -5,8 +5,6 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link href='https://fonts.googleapis.com/css?family=Roboto:300,700'
-              rel='stylesheet' type='text/css'/>
         <link rel="stylesheet" type="text/css" href="/www/main.css"/>
     </head>
     <body{{#if isDoc}} class="docs-page"{{/if}}>
@@ -46,5 +44,20 @@
             <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
             <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
         </div>
+
+        <script>
+        WebFontConfig = {
+          google: {
+            families: ['Roboto:300,700']
+          }
+        };
+
+        (function(d) {
+          var wf = d.createElement('script'), s = d.scripts[0]
+          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
+          wf.async = true
+          s.parentNode.insertBefore(wf, s)
+        })(document)
+        </script>
     </body>
 </html>

--- a/docs/layouts/template.html
+++ b/docs/layouts/template.html
@@ -8,8 +8,6 @@
 <style>
 {{css}}
 </style>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body{{#if isDoc}} class="docs-page"{{/if}}>
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -55,13 +53,13 @@
             families: ['Roboto:300,700']
           }
         };
-
-        (function(d) {
-          var wf = d.createElement('script'), s = d.scripts[0]
-          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
-          wf.async = true
-          s.parentNode.insertBefore(wf, s)
-        })(document)
+        </script>
+        <script async src="//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js"></script>
+        <script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>
+        document.querySelector('#highlight-js').addEventListener('load', function() {
+          hljs.initHighlightingOnLoad();
+        })
         </script>
     </body>
 </html>

--- a/docs/make.js
+++ b/docs/make.js
@@ -7,7 +7,6 @@ const headings = require('metalsmith-headings')
 const layouts = require('metalsmith-layouts')
 const collections = require('metalsmith-collections')
 const paths = require('metalsmith-paths')
-const highlight = require('metalsmith-code-highlight')
 
 const Handlebars = require('handlebars')
 Handlebars.registerHelper('eq', (a, b) => a === b)
@@ -56,7 +55,6 @@ Metalsmith(__dirname)
     smartypants: true,
     gfm: true,
   }))
-  .use(highlight())
   .use(headings('h3'))
   .use(layouts({
     engine: 'handlebars',

--- a/docs/make.js
+++ b/docs/make.js
@@ -1,3 +1,6 @@
+
+const fs = require('fs')
+
 const Metalsmith = require('metalsmith')
 const markdown = require('metalsmith-markdown')
 const headings = require('metalsmith-headings')
@@ -31,6 +34,7 @@ const docs = articles => (files, metalsmith, done) => {
 Metalsmith(__dirname)
   .metadata({
     version: require('../package.json').version,
+    css: fs.readFileSync('../www/main.css', 'utf-8'),
   })
   .source('md/')
   .destination('.')

--- a/docs/make.js
+++ b/docs/make.js
@@ -5,7 +5,6 @@ const Metalsmith = require('metalsmith')
 const markdown = require('metalsmith-markdown')
 const headings = require('metalsmith-headings')
 const layouts = require('metalsmith-layouts')
-const collections = require('metalsmith-collections')
 const paths = require('metalsmith-paths')
 
 const Handlebars = require('handlebars')
@@ -14,8 +13,6 @@ Handlebars.registerHelper('eq', (a, b) => a === b)
 /*
 const debug = (files, metalsmith, done) => {
   setImmediate(done)
-  console.log(metalsmith.metadata().collections.articles)
-  console.log(metalsmith.metadata().collections.articles[0].paths)
 }
 */
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -614,18 +614,6 @@
         "win-fork": "1.1.1"
       }
     },
-    "metalsmith-collections": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-collections/-/metalsmith-collections-0.9.0.tgz",
-      "integrity": "sha1-oNGTR6UdX70CaJnfwfTWivUODhc=",
-      "requires": {
-        "debug": "2.6.8",
-        "extend": "3.0.1",
-        "multimatch": "2.1.0",
-        "read-metadata": "1.0.0",
-        "uniq": "1.0.1"
-      }
-    },
     "metalsmith-headings": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/metalsmith-headings/-/metalsmith-headings-0.2.0.tgz",
@@ -766,14 +754,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
       "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
       "dev": true
-    },
-    "read-metadata": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-metadata/-/read-metadata-1.0.0.tgz",
-      "integrity": "sha1-bfnL5RGE6M630GaLQO5Rkebz2sY=",
-      "requires": {
-        "yaml-js": "0.0.8"
-      }
     },
     "readable-stream": {
       "version": "1.1.14",
@@ -920,11 +900,6 @@
         "qs": "2.3.3"
       }
     },
-    "uniq": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
-    },
     "unyield": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/unyield/-/unyield-0.0.1.tgz",
@@ -975,11 +950,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "yaml-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/yaml-js/-/yaml-js-0.0.8.tgz",
-      "integrity": "sha1-h8+lqWE/SOJgBUINao7g2m/o2uw="
     },
     "yargs": {
       "version": "3.10.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -295,11 +295,6 @@
         "domelementtype": "1.3.0"
       }
     },
-    "domino": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/domino/-/domino-1.0.29.tgz",
-      "integrity": "sha1-3oqh9vmOPFU4/remH6acHqu6zgY="
-    },
     "domutils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
@@ -448,11 +443,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
-    },
-    "highlight.js": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-8.9.1.tgz",
-      "integrity": "sha1-uKnFSTISqTkvAiK2SclhFJfr+4g="
     },
     "htmlparser2": {
       "version": "3.7.3",
@@ -622,15 +612,6 @@
         "unyield": "0.0.1",
         "ware": "1.3.0",
         "win-fork": "1.1.1"
-      }
-    },
-    "metalsmith-code-highlight": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/metalsmith-code-highlight/-/metalsmith-code-highlight-0.0.4.tgz",
-      "integrity": "sha512-+SCKHWplICZhMH3fOLTEkjXTwlnqkO8KGvNXqmj7pYC9lnmCgckyPdkCwXqY+ra+8ik4kUawTsDJTvM1Z+6q/g==",
-      "requires": {
-        "domino": "1.0.29",
-        "highlight.js": "8.9.1"
       }
     },
     "metalsmith-collections": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "handlebars": "^4.0.10",
     "metalsmith": "^2.3.0",
-    "metalsmith-collections": "^0.9.0",
     "metalsmith-headings": "^0.2.0",
     "metalsmith-layouts": "^1.8.1",
     "metalsmith-markdown": "^0.2.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "handlebars": "^4.0.10",
     "metalsmith": "^2.3.0",
-    "metalsmith-code-highlight": "0.0.4",
     "metalsmith-collections": "^0.9.0",
     "metalsmith-headings": "^0.2.0",
     "metalsmith-layouts": "^1.8.1",

--- a/docs/tooling.html
+++ b/docs/tooling.html
@@ -257,8 +257,6 @@ nav a {
 
 
 </style>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -378,13 +376,13 @@ compile grammars with a gulpfile.</p>
             families: ['Roboto:300,700']
           }
         };
-
-        (function(d) {
-          var wf = d.createElement('script'), s = d.scripts[0]
-          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
-          wf.async = true
-          s.parentNode.insertBefore(wf, s)
-        })(document)
+        </script>
+        <script async src="//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js"></script>
+        <script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>
+        document.querySelector('#highlight-js').addEventListener('load', function() {
+          hljs.initHighlightingOnLoad();
+        })
         </script>
     </body>
 </html>

--- a/docs/tooling.html
+++ b/docs/tooling.html
@@ -5,8 +5,6 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link href='https://fonts.googleapis.com/css?family=Roboto:300,700'
-              rel='stylesheet' type='text/css'/>
         <link rel="stylesheet" type="text/css" href="/www/main.css"/>
     </head>
     <body class="docs-page">
@@ -120,5 +118,20 @@ compile grammars with a gulpfile.</p>
             <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
             <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
         </div>
+
+        <script>
+        WebFontConfig = {
+          google: {
+            families: ['Roboto:300,700']
+          }
+        };
+
+        (function(d) {
+          var wf = d.createElement('script'), s = d.scripts[0]
+          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
+          wf.async = true
+          s.parentNode.insertBefore(wf, s)
+        })(document)
+        </script>
     </body>
 </html>

--- a/docs/tooling.html
+++ b/docs/tooling.html
@@ -5,7 +5,258 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link rel="stylesheet" type="text/css" href="/www/main.css"/>
+<style>
+body {
+    font-family: sans-serif;
+    font-weight: 300;
+    font-size: 15pt;
+    margin: 0px;
+    padding: 0px;
+    border-top: 0.1em #559 solid;
+    border-bottom: 0.1em #559 solid;
+}
+
+.wf-roboto-n3-active body {
+  font-family: Roboto, sans-serif;
+}
+
+#main a {
+    color: #55a;
+}
+#main a:visited {
+    color: #55a;
+}
+#main a:hover {
+    color: #259;
+}
+
+h1 {
+    font-size: 1.6em;
+    font-weight: 100;
+    letter-spacing: 0.5em;
+    text-align: center;
+    margin-top: 3em;
+    margin-bottom: 3em;
+}
+
+h1 a {
+    text-decoration: none;
+}
+
+h1:hover {
+    color: #559;
+    cursor: pointer;
+}
+
+#version {
+    background: orange;
+    border-radius: 50%;
+    font-weight: bold;
+    color: white;
+    width: 3.5em;
+    height: 3.5em;
+    display: inline-block;
+    text-align: center;
+    line-height: 3.5em;
+    letter-spacing: 0em;
+}
+
+h2 {
+    margin-top: 4em;
+}
+h3 {
+    margin-top: 3em;
+}
+h4 {
+    margin-top: 3em;
+}
+
+.center {
+    padding-left: 2em;
+    padding-right: 2em;
+    margin-left: auto;
+    margin-right: auto;
+}
+#main {
+    max-width: 35em;
+}
+
+#main p, ul, ol {
+    line-height: 1.5em;
+    margin-bottom: 1em;
+}
+
+#main li {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+#main ul li {
+    list-style: none;
+    min-width: 10em;
+}
+#main ul li:before {
+    display: inline-block;
+    content: &quot;\2014&quot;;
+    margin-left: -1.5em;
+    width: 1.5em;
+}
+
+#main textarea {
+    width: 100%;
+    height: 20em;
+    resize: none;
+    margin-top: 5px;
+    margin-bottom: 5px;
+
+    font-family: menlo, monaco, monospace;
+    font-size: 10pt;
+    padding: 5px;
+
+    border: none;
+    border-left: solid 1px #aaa;
+}
+#main textarea:focus {
+    outline: none;
+}
+
+#main img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 100%;
+}
+img + .caption {
+    text-align: center;
+    font-size: 0.7em;
+    color: #aaa;
+}
+
+/*
+#cy-viz {
+    width: 100%;
+}*/
+
+#footer {
+    margin-top: 10em;
+    color: #aaa;
+    font-size: 0.7em;
+    padding: 5em;
+}
+
+code {
+    margin-left: 0.2em;
+    margin-right: 0.2em;
+    padding: 0.2em;
+    border-radius: 0.2em;
+    background-color: #eee;
+}
+
+pre code {
+    border-radius: 0.5em;
+    //background-color: #559;
+    //color: white;
+    //text-shadow: 0em 0em 0.2em black;
+    padding: 0.5em;
+    display: block;
+    overflow: auto;
+}
+
+
+ol.tutorial {
+    counter-reset: tutorial-counter;
+}
+
+ol.tutorial li {
+    list-style: none;
+}
+
+ol.tutorial li:before {
+    content: counter(tutorial-counter);
+    counter-increment: tutorial-counter;
+
+    font-weight: bold;
+    border-radius: 50%;
+    background-color: #559;
+    width: 2em;
+    height: 2em;
+    display: inline-block;
+    text-align: center;
+    line-height: 2em;
+    color: white;
+
+    margin-left: -2em;
+
+    position: relative;
+    right: 1em;
+}
+
+input[type&#x3D;&quot;text&quot;] {
+    border: none;
+    font-family: monospace;
+    font-size: 1em;
+    color: #559;
+}
+
+input[type&#x3D;&quot;text&quot;]:focus {
+    outline: none;
+}
+
+
+nav {
+    border-right: 1px solid #aaa;
+    background: #fff;
+}
+nav ul {
+    padding: 0;
+    margin: 0;
+}
+nav a {
+    text-decoration: none;
+    color: #000;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0.25em 0.5em; */
+}
+.page {
+    display: block;
+    border-bottom: 1px solid #aaa;
+}
+
+.page-title-active {
+    background: #559;
+    color: #fff;
+}
+
+.page-heading {
+    display: block;
+    padding-left: 1em;
+}
+
+
+@media screen and (min-width: 36rem) {
+    nav {
+        position: fixed;
+        width: 16rem;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        white-space: nowrap;
+        overflow-y: auto;
+        font-size: 1rem;
+    }
+    body.docs-page {
+        margin-left: 16rem;
+    }
+}
+
+/* highlight.js */
+
+.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
+
+
+</style>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>

--- a/docs/tooling.html
+++ b/docs/tooling.html
@@ -257,6 +257,8 @@ nav a {
 
 
 </style>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -286,17 +288,17 @@ nav a {
 <p>nearley ships with a host of tools to help you develop, test, and maintain your
 grammars easily.</p>
 <h3 id="nearley-test-exploring-a-parser-interactively">nearley-test: Exploring a parser interactively</h3>
-<p class="lang-highlight">A global install of nearley provides <code class="lang-stata">nearley-<span class="hljs-keyword">test</span></code>, a simple command-line tool
+<p>A global install of nearley provides <code>nearley-test</code>, a simple command-line tool
 you can use to inspect what a parser is doing. You input a generated
-<code class="lang-css"><span class="hljs-tag">grammar</span><span class="hljs-class">.js</span></code> file, and then give it some input to test the parser against.
-<code class="lang-stata">nearley-<span class="hljs-keyword">test</span></code> prints out the output if successful, and optionally
+<code>grammar.js</code> file, and then give it some input to test the parser against.
+<code>nearley-test</code> prints out the output if successful, and optionally
 pretty-prints the internal parse table used by the algorithm. This is helpful
 to test a new parser.</p>
 <h3 id="nearley-unparse-the-unparser">nearley-unparse: The Unparser</h3>
 <p>The Unparser takes a (compiled) parser and outputs a random string that would
 be accepted by the parser.</p>
-<pre class="lang-highlight"><code class="lang-bash">$ nearley-unparse <span class="hljs-operator">-s</span> number &lt;(nearleyc <span class="hljs-built_in">builtin</span>/prims.ne)
--<span class="hljs-number">6.22</span>E94
+<pre><code class="lang-bash">$ nearley-unparse -s number &lt;(nearleyc builtin/prims.ne)
+-6.22E94
 </code></pre>
 <p>You can use the Unparser to…</p>
 <ul>
@@ -311,8 +313,8 @@ grammatically valid loremtext.)</li>
 <p>The Unparser outputs as a stream by continuously writing characters to its
 output pipe. So, if it “goes off the deep end” and generates a huge string, you
 will still see output scrolling by in real-time.</p>
-<p class="lang-highlight">To limit the size of the output, you can specify a bound on the depth with the
-<code class="lang-bash"><span class="hljs-operator">-d</span></code> flag. This switches the Unparser to a different algorithm. A larger depth
+<p>To limit the size of the output, you can specify a bound on the depth with the
+<code>-d</code> flag. This switches the Unparser to a different algorithm. A larger depth
 bound corresponds to larger generated strings.</p>
 <p>As far as I know, nearley is the only parser generator with this feature. It
 is inspired by Roly Fentanes’ <a href="https://fent.github.io/randexp.js/">randexp</a>,
@@ -320,12 +322,12 @@ which does the same thing with regular expressions.</p>
 <h3 id="nearley-railroad-automagical-railroad-diagrams">nearley-railroad: Automagical Railroad Diagrams</h3>
 <p>nearley lets you convert your grammars to pretty SVG railroad diagrams that you
 can include in webpages, documentation, and even papers.</p>
-<pre class="lang-highlight"><code class="lang-bash">$ nearley-railroad regex.ne -o grammar.html
+<pre><code class="lang-bash">$ nearley-railroad regex.ne -o grammar.html
 </code></pre>
 <p><img src="/www/railroad-demo.png" alt="Railroad demo"></p>
 <p>See a bigger example <a href="http://nearley.js.org/www/railroad-demo.html">here</a>.</p>
 <p>(This feature is powered by
-<a href="https://github.com/tabatkins/railroad-diagrams" class="lang-highlight"><code>railroad-diagrams</code></a> by
+<a href="https://github.com/tabatkins/railroad-diagrams"><code>railroad-diagrams</code></a> by
 tabatkins.)</p>
 <h3 id="other-tools">Other Tools</h3>
 <p><em>This section lists nearley tooling created by other developers. These tools

--- a/docs/using-in-frontend.html
+++ b/docs/using-in-frontend.html
@@ -5,7 +5,258 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link rel="stylesheet" type="text/css" href="/www/main.css"/>
+<style>
+body {
+    font-family: sans-serif;
+    font-weight: 300;
+    font-size: 15pt;
+    margin: 0px;
+    padding: 0px;
+    border-top: 0.1em #559 solid;
+    border-bottom: 0.1em #559 solid;
+}
+
+.wf-roboto-n3-active body {
+  font-family: Roboto, sans-serif;
+}
+
+#main a {
+    color: #55a;
+}
+#main a:visited {
+    color: #55a;
+}
+#main a:hover {
+    color: #259;
+}
+
+h1 {
+    font-size: 1.6em;
+    font-weight: 100;
+    letter-spacing: 0.5em;
+    text-align: center;
+    margin-top: 3em;
+    margin-bottom: 3em;
+}
+
+h1 a {
+    text-decoration: none;
+}
+
+h1:hover {
+    color: #559;
+    cursor: pointer;
+}
+
+#version {
+    background: orange;
+    border-radius: 50%;
+    font-weight: bold;
+    color: white;
+    width: 3.5em;
+    height: 3.5em;
+    display: inline-block;
+    text-align: center;
+    line-height: 3.5em;
+    letter-spacing: 0em;
+}
+
+h2 {
+    margin-top: 4em;
+}
+h3 {
+    margin-top: 3em;
+}
+h4 {
+    margin-top: 3em;
+}
+
+.center {
+    padding-left: 2em;
+    padding-right: 2em;
+    margin-left: auto;
+    margin-right: auto;
+}
+#main {
+    max-width: 35em;
+}
+
+#main p, ul, ol {
+    line-height: 1.5em;
+    margin-bottom: 1em;
+}
+
+#main li {
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+#main ul li {
+    list-style: none;
+    min-width: 10em;
+}
+#main ul li:before {
+    display: inline-block;
+    content: &quot;\2014&quot;;
+    margin-left: -1.5em;
+    width: 1.5em;
+}
+
+#main textarea {
+    width: 100%;
+    height: 20em;
+    resize: none;
+    margin-top: 5px;
+    margin-bottom: 5px;
+
+    font-family: menlo, monaco, monospace;
+    font-size: 10pt;
+    padding: 5px;
+
+    border: none;
+    border-left: solid 1px #aaa;
+}
+#main textarea:focus {
+    outline: none;
+}
+
+#main img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 100%;
+}
+img + .caption {
+    text-align: center;
+    font-size: 0.7em;
+    color: #aaa;
+}
+
+/*
+#cy-viz {
+    width: 100%;
+}*/
+
+#footer {
+    margin-top: 10em;
+    color: #aaa;
+    font-size: 0.7em;
+    padding: 5em;
+}
+
+code {
+    margin-left: 0.2em;
+    margin-right: 0.2em;
+    padding: 0.2em;
+    border-radius: 0.2em;
+    background-color: #eee;
+}
+
+pre code {
+    border-radius: 0.5em;
+    //background-color: #559;
+    //color: white;
+    //text-shadow: 0em 0em 0.2em black;
+    padding: 0.5em;
+    display: block;
+    overflow: auto;
+}
+
+
+ol.tutorial {
+    counter-reset: tutorial-counter;
+}
+
+ol.tutorial li {
+    list-style: none;
+}
+
+ol.tutorial li:before {
+    content: counter(tutorial-counter);
+    counter-increment: tutorial-counter;
+
+    font-weight: bold;
+    border-radius: 50%;
+    background-color: #559;
+    width: 2em;
+    height: 2em;
+    display: inline-block;
+    text-align: center;
+    line-height: 2em;
+    color: white;
+
+    margin-left: -2em;
+
+    position: relative;
+    right: 1em;
+}
+
+input[type&#x3D;&quot;text&quot;] {
+    border: none;
+    font-family: monospace;
+    font-size: 1em;
+    color: #559;
+}
+
+input[type&#x3D;&quot;text&quot;]:focus {
+    outline: none;
+}
+
+
+nav {
+    border-right: 1px solid #aaa;
+    background: #fff;
+}
+nav ul {
+    padding: 0;
+    margin: 0;
+}
+nav a {
+    text-decoration: none;
+    color: #000;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0.25em 0.5em; */
+}
+.page {
+    display: block;
+    border-bottom: 1px solid #aaa;
+}
+
+.page-title-active {
+    background: #559;
+    color: #fff;
+}
+
+.page-heading {
+    display: block;
+    padding-left: 1em;
+}
+
+
+@media screen and (min-width: 36rem) {
+    nav {
+        position: fixed;
+        width: 16rem;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        white-space: nowrap;
+        overflow-y: auto;
+        font-size: 1rem;
+    }
+    body.docs-page {
+        margin-left: 16rem;
+    }
+}
+
+/* highlight.js */
+
+.hljs{display:block;overflow-x:auto;padding:0.5em;background:#F0F0F0}.hljs,.hljs-subst{color:#444}.hljs-comment{color:#888888}.hljs-keyword,.hljs-attribute,.hljs-selector-tag,.hljs-meta-keyword,.hljs-doctag,.hljs-name{font-weight:bold}.hljs-type,.hljs-string,.hljs-number,.hljs-selector-id,.hljs-selector-class,.hljs-quote,.hljs-template-tag,.hljs-deletion{color:#880000}.hljs-title,.hljs-section{color:#880000;font-weight:bold}.hljs-regexp,.hljs-symbol,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-selector-attr,.hljs-selector-pseudo{color:#BC6060}.hljs-literal{color:#78A960}.hljs-built_in,.hljs-bullet,.hljs-code,.hljs-addition{color:#397300}.hljs-meta{color:#1f7199}.hljs-meta-string{color:#4d99bf}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
+
+
+</style>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>

--- a/docs/using-in-frontend.html
+++ b/docs/using-in-frontend.html
@@ -257,6 +257,8 @@ nav a {
 
 
 </style>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -277,42 +279,42 @@ nav a {
             <h1><a href="/">nearley<span style="color: #559;">.js</span><span id="version">2.10.4</span></a></h1>
 
 <h2>Compiling in browsers</h2>
-<p class="lang-highlight">Both the nearley parser and compiled grammars work in browsers; simply include
-<code class="lang-css"><span class="hljs-tag">nearley</span><span class="hljs-class">.js</span></code> and your compiled <code class="lang-css"><span class="hljs-tag">grammar</span><span class="hljs-class">.js</span></code> file in <code class="lang-xml"><span class="hljs-tag">&lt;<span class="hljs-title">script</span>&gt;</span><span class="undefined"></span></code> tags and use
+<p>Both the nearley parser and compiled grammars work in browsers; simply include
+<code>nearley.js</code> and your compiled <code>grammar.js</code> file in <code>&lt;script&gt;</code> tags and use
 nearley as usual. However, the nearley <em>compiler</em> is not designed for the
 browser – you should precompile your grammars and only serve the generated JS
 files to browsers.</p>
-<p class="lang-highlight">If you absolutely have to compile a grammar in a browser (for example, to
+<p>If you absolutely have to compile a grammar in a browser (for example, to
 implement a nearley IDE) then you can use a tool like
 <a href="https://webpack.js.org/">Webpack</a> or <a href="https://rollupjs.org/">Rollup</a> to
 include the <code>nearley</code> NPM package in your browser code. Then, you can utilize
 the <code>nearleyc</code> internals to compile grammars dynamically.</p>
-<pre class="lang-highlight"><code class="lang-js"><span class="hljs-keyword">const</span> nearley = <span class="hljs-built_in">require</span>(<span class="hljs-string">"nearley"</span>);
-<span class="hljs-keyword">const</span> compile = <span class="hljs-built_in">require</span>(<span class="hljs-string">"nearley/lib/compile"</span>);
-<span class="hljs-keyword">const</span> generate = <span class="hljs-built_in">require</span>(<span class="hljs-string">"nearley/lib/generate"</span>);
-<span class="hljs-keyword">const</span> nearleyGrammar = <span class="hljs-built_in">require</span>(<span class="hljs-string">"nearley/lib/nearley-language-bootstrapped"</span>);
+<pre><code class="lang-js">const nearley = require(&quot;nearley&quot;);
+const compile = require(&quot;nearley/lib/compile&quot;);
+const generate = require(&quot;nearley/lib/generate&quot;);
+const nearleyGrammar = require(&quot;nearley/lib/nearley-language-bootstrapped&quot;);
 
-<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">compileGrammar</span>(<span class="hljs-params">sourceCode</span>) </span>{
-    <span class="hljs-comment">// Parse the grammar source into an AST</span>
-    <span class="hljs-keyword">const</span> grammarParser = <span class="hljs-keyword">new</span> nearley.Parser(nearleyGrammar);
+function compileGrammar(sourceCode) {
+    // Parse the grammar source into an AST
+    const grammarParser = new nearley.Parser(nearleyGrammar);
     grammarParser.feed(sourceCode);
-    <span class="hljs-keyword">const</span> grammarAst = grammarParser.results[<span class="hljs-number">0</span>]; <span class="hljs-comment">// TODO check for errors</span>
+    const grammarAst = grammarParser.results[0]; // TODO check for errors
 
-    <span class="hljs-comment">// Compile the AST into a set of rules</span>
-    <span class="hljs-keyword">const</span> grammarInfoObject = compile(grammarAst, {});
-    <span class="hljs-comment">// Generate JavaScript code from the rules</span>
-    <span class="hljs-keyword">const</span> grammarJs = generate(grammarInfoObject, <span class="hljs-string">"grammar"</span>);
+    // Compile the AST into a set of rules
+    const grammarInfoObject = compile(grammarAst, {});
+    // Generate JavaScript code from the rules
+    const grammarJs = generate(grammarInfoObject, &quot;grammar&quot;);
 
-    <span class="hljs-comment">// Pretend this is a CommonJS environment to catch exports from the grammar.</span>
-    <span class="hljs-keyword">const</span> <span class="hljs-built_in">module</span> = { exports: {} };
-    <span class="hljs-built_in">eval</span>(grammarJs);
+    // Pretend this is a CommonJS environment to catch exports from the grammar.
+    const module = { exports: {} };
+    eval(grammarJs);
 
-    <span class="hljs-keyword">return</span> <span class="hljs-built_in">module</span>.exports;
+    return module.exports;
 }
 
-<span class="hljs-keyword">const</span> grammar = compileGrammar(<span class="hljs-string">"main -&gt; foo | bar"</span>);
+const grammar = compileGrammar(&quot;main -&gt; foo | bar&quot;);
 
-<span class="hljs-keyword">const</span> parser = <span class="hljs-keyword">new</span> nearley.Parser(nearley.Grammar.fromCompiled(grammar));
+const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
 </code></pre>
 
 

--- a/docs/using-in-frontend.html
+++ b/docs/using-in-frontend.html
@@ -257,8 +257,6 @@ nav a {
 
 
 </style>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-        <script>hljs.initHighlightingOnLoad();</script>
     </head>
     <body class="docs-page">
         <a href="https://github.com/Hardmath123/nearley" class="github-corner"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: absolute; top: 0; border: 0; right: 0;"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
@@ -334,13 +332,13 @@ const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
             families: ['Roboto:300,700']
           }
         };
-
-        (function(d) {
-          var wf = d.createElement('script'), s = d.scripts[0]
-          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
-          wf.async = true
-          s.parentNode.insertBefore(wf, s)
-        })(document)
+        </script>
+        <script async src="//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js"></script>
+        <script id="highlight-js" async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script>
+        document.querySelector('#highlight-js').addEventListener('load', function() {
+          hljs.initHighlightingOnLoad();
+        })
         </script>
     </body>
 </html>

--- a/docs/using-in-frontend.html
+++ b/docs/using-in-frontend.html
@@ -5,8 +5,6 @@
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="nearley.js is a simple, fast, and powerful parser toolkit for JavaScript." />
-        <link href='https://fonts.googleapis.com/css?family=Roboto:300,700'
-              rel='stylesheet' type='text/css'/>
         <link rel="stylesheet" type="text/css" href="/www/main.css"/>
     </head>
     <body class="docs-page">
@@ -76,5 +74,20 @@ the <code>nearleyc</code> internals to compile grammars dynamically.</p>
             <a href="https://js.org" target="_blank" title="JS.ORG | JavaScript Community">
             <img src="https://logo.js.org/dark_horz.png" width="102" alt="JS.ORG Logo"/></a>
         </div>
+
+        <script>
+        WebFontConfig = {
+          google: {
+            families: ['Roboto:300,700']
+          }
+        };
+
+        (function(d) {
+          var wf = d.createElement('script'), s = d.scripts[0]
+          wf.src = '//cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js'
+          wf.async = true
+          s.parentNode.insertBefore(wf, s)
+        })(document)
+        </script>
     </body>
 </html>

--- a/www/main.css
+++ b/www/main.css
@@ -1,11 +1,15 @@
 body {
-    font-family: 'Roboto', sans-serif;
+    font-family: sans-serif;
     font-weight: 300;
     font-size: 15pt;
     margin: 0px;
     padding: 0px;
     border-top: 0.1em #559 solid;
     border-bottom: 0.1em #559 solid;
+}
+
+.wf-roboto-n3-active body {
+  font-family: Roboto, sans-serif;
 }
 
 #main a {


### PR DESCRIPTION
This avoids FOIT in favour of FOUT: that is, show a fallback font while the webfont (Roboto) is loading. This means the content is readable in half the time, on a slow connection. (This is how `@font-face` used to work, before browsers changed their behaviour.)

This also inlines the CSS, to avoid an additional blocking request before the content can be rendered.

Before (>7s to content):
<img width="915" alt="screen shot 2017-08-18 at 13 42 49" src="https://user-images.githubusercontent.com/639289/29459500-cd95f42e-841b-11e7-9c27-1e17bd380f36.png">

---
After: (<3s to content):
<img width="1209" alt="screen shot 2017-08-18 at 13 43 24" src="https://user-images.githubusercontent.com/639289/29459499-cd956c20-841b-11e7-97ae-e74cb24c0bac.png">
