### PR TITLE
Exclude tests & docs from NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "files": [
     "bin/",
     "lib/",
-    "builtin/",
-    "examples/"
+    "builtin/"
   ],
   "bin": {
     "nearleyc": "bin/nearleyc.js",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
     "railroad-diagrams": "^1.0.0",
     "randexp": "^0.4.2"
   },
+  "files": [
+    "bin/",
+    "lib/",
+    "builtin/",
+    "examples/"
+  ],
   "bin": {
     "nearleyc": "bin/nearleyc.js",
     "nearley-test": "bin/nearley-test.js",


### PR DESCRIPTION
* This brings the package size from 1.6M -> 432K.
* Reducing the package size is nice; it means our users have less to download.
* README.md & LICENSE.txt will be included automatically.
* I'd rather not include `examples/`, but there's a small chance someone will
depend on it?

People on rubbish connections (as I sometimes am!) should appreciate this. :-)