### PR TITLE
Ditch deprecated nomnom in favor of commander

### DIFF
--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -10,26 +10,19 @@ try {
 
 var fs = require('fs');
 var path = require('path');
-var nomnom = require('nomnom');
+var opts = require('commander');
 
-var opts = nomnom
-    .script('nearley-railroad')
-    .option('file', {
-        position: 0,
-        help: "A grammar .ne file (default stdin)"
-    })
-    .option('out', {
-        abbr: 'o',
-        help: "File to output to (default stdout)."
-    })
-    .option('version', {
-        abbr: 'v',
-        flag: true,
-        help: "Print version and exit",
-        callback: function() {
-            return require('../package.json').version;
-        }
-    }).parse();
+opts
+    .description('Generate pretty railroad diagrams from a parser')
+    .usage('[file] [options]')
+    .option(
+        '-o, --out <file>',
+        'File to output to (defaults to stdout)'
+    )
+    .version(require('../package.json').version)
+    .parse(process.argv);
+
+opts.file = opts.args[0]
 
 var input = opts.file ? fs.createReadStream(opts.file) : process.stdin;
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;

--- a/bin/nearley-test.js
+++ b/bin/nearley-test.js
@@ -6,43 +6,33 @@
 
 var fs = require('fs');
 var nearley = require('../lib/nearley.js');
-var nomnom = require('nomnom');
+var opts = require('commander');
 var StreamWrapper = require('../lib/stream.js');
 
-var opts = nomnom
-    .script('nearley-test')
-    .option('file', {
-        position: 0,
-        help: "A grammar .js file",
-        required: true,
-    })
-    .option('input', {
-        abbr: 'i',
-        help: "An input string to parse (if not provided then read from stdin)",
-        type: 'string',
-    })
-    .option('start', {
-        abbr: 's',
-        help: "An optional start symbol (if not provided then use the parser start symbol)",
-    })
-    .option('out', {
-        abbr: 'o',
-        help: "File to output to (defaults to stdout)",
-    })
-    .option('quiet', {
-        abbr: 'q',
-        flag: true,
-        help: "Output parse results only (hide Earley table)",
-    })
-    .option('version', {
-        abbr: 'v',
-        flag: true,
-        help: "Print version and exit",
-        callback: function() {
-            return require('../package.json').version;
-        }
-    })
-    .parse();
+opts
+    .description('Test a grammar against some input and see the results')
+    .usage('[file] [options]')
+    .option(
+        '-i, --input <file>',
+        'An input string to parse (if not provided then read from stdin)'
+    )
+    .option(
+        '-s, --start <symbol>',
+        'An optional start symbol (if not provided then use the parser start symbol)'
+    )
+    .option(
+        '-o, --out <file>',
+        'File to output to (defaults to stdout)'
+    )
+    .option(
+        '-q, --quiet',
+        'Output parse results only (hide Earley table)',
+        false
+    )
+    .version(require('../package.json').version)
+    .parse(process.argv);
+
+opts.file = opts.args[0]
 
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 

--- a/bin/nearley-unparse.js
+++ b/bin/nearley-unparse.js
@@ -2,43 +2,40 @@
 
 var fs = require('fs');
 var nearley = require('../lib/nearley.js');
-var nomnom = require('nomnom');
+var opts = require('commander');
 var randexp = require('randexp');
 
-var opts = nomnom
-    .script('nearley-unparse')
-    .option('file', {
-        position: 0,
-        help: "A grammar .js file",
-        required: true,
-    })
-    .option('start', {
-        abbr: 's',
-        help: "An optional start symbol (if not provided then use the parser start symbol)",
-    })
-    .option('count', {
-        abbr: 'n',
-        help: 'The number of samples to generate (separated by \\n).',
-        default: 1
-    })
-    .option('depth', {
-        abbr: 'd',
-        help: 'The depth bound of each sample. Defaults to -1, which means "unbounded".',
-        default: -1
-    })
-    .option('out', {
-        abbr: 'o',
-        help: "File to output to (defaults to stdout)",
-    })
-    .option('version', {
-        abbr: 'v',
-        flag: true,
-        help: "Print version and exit",
-        callback: function() {
-            return require('../package.json').version;
-        }
-    })
-    .parse();
+function parseDecimal (string) {
+  return parseInt(string, 10)
+}
+
+opts
+    .description('Invert a parser into a generator')
+    .usage('<file> [options]')
+    .option(
+        '-s, --start <symbol>',
+        'An optional start symbol (if not provided then use the parser start symbol)'
+    )
+    .option(
+        '-n, --count <n>',
+        'The number of samples to generate (separated by \\n)',
+        parseDecimal,
+        1
+    )
+    .option(
+        '-d, --depth <n>',
+        'The depth bound of each sample. Defaults to -1, which means "unbounded"',
+        parseDecimal,
+        -1
+    )
+    .option(
+        '-o, --out <file>',
+        'File to output to (defaults to stdout)'
+    )
+    .version(require('../package.json').version)
+    .parse(process.argv);
+
+opts.file = opts.args[0]
 
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 

--- a/bin/nearleyc.js
+++ b/bin/nearleyc.js
@@ -2,39 +2,31 @@
 
 var fs = require('fs');
 var nearley = require('../lib/nearley.js');
-var nomnom = require('nomnom');
+var opts = require('commander');
 var Compile = require('../lib/compile.js');
 var StreamWrapper = require('../lib/stream.js');
 
-var opts = nomnom
-    .script('nearleyc')
-    .option('file', {
-        position: 0,
-        help: "An input .ne file (if not provided then read from stdin)",
-    })
-    .option('out', {
-        abbr: 'o',
-        help: "File to output to (defaults to stdout)",
-    })
-    .option('export', {
-        abbr: 'e',
-        help: "Variable to set the parser to",
-        default: "grammar"
-    })
-    .option('nojs', {
-        flag: true,
-        default: false,
-        help: "Don't compile postprocessors (for testing)."
-    })
-    .option('version', {
-        abbr: 'v',
-        flag: true,
-        help: "Print version and exit",
-        callback: function() {
-            return require('../package.json').version;
-        }
-    })
-    .parse();
+opts
+    .description('Compile grammar files to JavaScript')
+    .usage('[file] [options]')
+    .option(
+        '-o, --out <file>',
+        'File to output to (defaults to stdout)'
+    )
+    .option(
+        '-e, --export <name>',
+        'Variable to set the parser to',
+        'grammar'
+    )
+    .option(
+        '-N, --nojs',
+        "Don't compile postprocessors (for testing)",
+        false
+    )
+    .version(require('../package.json').version)
+    .parse(process.argv);
+
+opts.file = opts.args[0]
 
 var input = opts.file ? fs.createReadStream(opts.file) : process.stdin;
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.39.tgz",
-      "integrity": "sha512-KQHAZeVsk4UIT9XaR6cn4WpHZzimK6UBD1UomQKfQQFmTlUHaNBzeuov+TM4+kigLO0IJt4I5OOsshcCyA9gSA==",
+      "version": "7.0.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.43.tgz",
+      "integrity": "sha512-7scYwwfHNppXvH/9JzakbVxk0o0QUILVk1Lv64GRaxwPuGpnF1QBiwdvhDpLcymb8BpomQL3KYoWKq3wUdDMhQ==",
       "dev": true
     },
     "anchor-markdown-header": {
@@ -115,18 +115,10 @@
       "dev": true,
       "requires": {
         "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.2",
+        "escape-string-regexp": "1.0.5",
         "has-ansi": "2.0.0",
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "character-entities": {
@@ -184,10 +176,10 @@
       "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw=",
       "dev": true
     },
-    "colors": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-      "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -371,15 +363,15 @@
       }
     },
     "escape-string-regexp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "expand-template": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.0.3.tgz",
-      "integrity": "sha1-bDAzIxd6YrGyLAcCefeGEoe2mxo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
+      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ==",
       "dev": true
     },
     "expect": {
@@ -693,7 +685,7 @@
       "requires": {
         "bindings": "1.2.1",
         "nan": "2.6.2",
-        "prebuild-install": "2.2.1"
+        "prebuild-install": "2.2.2"
       }
     },
     "minimatch": {
@@ -762,10 +754,22 @@
             "ms": "0.7.1"
           }
         },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "dev": true
+        },
         "ms": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
           "dev": true
         }
       }
@@ -793,22 +797,6 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.0.tgz",
       "integrity": "sha512-AbW35CPRE4vdieOse46V+16dKispLNv3PQwgqlcfg7GQeQHcLu3gvp3fbU2gTh7d8NfGjp5CJh+j4Hpyb0XzaA==",
       "dev": true
-    },
-    "nomnom": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
-      "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
-      "requires": {
-        "colors": "0.5.1",
-        "underscore": "1.4.4"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
-        }
-      }
     },
     "noop-logger": {
       "version": "0.1.1",
@@ -900,12 +888,12 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.2.1.tgz",
-      "integrity": "sha512-y/sgNJ49vjXQ3qYdSI/jTRZq6D7g5Q2euK6x0/L8dvwK1EGvNLidtg2t4PZzTgkR6LahkzpYVshOmHKYtp0AlQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.2.2.tgz",
+      "integrity": "sha512-F46pcvDxtQhbV3B+dm+exHuKxIyJK26fVNiJRmbTW/5D7o0Z2yzc8CKeu7UWbo9XxQZoVOC88aKgySAsza+cWw==",
       "dev": true,
       "requires": {
-        "expand-template": "1.0.3",
+        "expand-template": "1.1.0",
         "github-from-package": "0.0.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
@@ -943,12 +931,12 @@
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
     },
     "randexp": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.5.tgz",
-      "integrity": "sha1-/+OoDD9mbNceawCOR35YTBoy/z4=",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
       "requires": {
         "discontinuous-range": "1.0.0",
-        "ret": "0.1.14"
+        "ret": "0.1.15"
       }
     },
     "rc": {
@@ -1029,9 +1017,9 @@
       "dev": true
     },
     "ret": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.14.tgz",
-      "integrity": "sha1-WMY2g3sS4WH4o4DPCBxqIw/RZk4="
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -1125,9 +1113,9 @@
       }
     },
     "supports-color": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "tar-fs": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple, fast, powerful parser toolkit for JavaScript.",
   "main": "lib/nearley.js",
   "dependencies": {
-    "nomnom": "~1.6.2",
+    "commander": "^2.11.0",
     "railroad-diagrams": "^1.0.0",
     "randexp": "^0.4.2"
   },


### PR DESCRIPTION
I tried to edit as little as possible. Some minor things to notice:

* commander's generated help has no color, unlike nomnom's
* commander has no positional elements, that means:
  - [file] can actually be passed last
  - but CLI usage remains backwards compatible
* I manually tested the all the CLI commands and options but it would
  be better if someone double checks.

Part of #208