### PR TITLE
Split up tests

### DIFF
--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -10,7 +10,7 @@ function read(filename) {
     return fs.readFileSync(filename, 'utf-8');
 }
 
-function inspect(grammar) {
+function prettyPrint(grammar) {
   return grammar.rules.map(g => g.toString())
 }
 
@@ -39,7 +39,7 @@ describe("bin/nearleyc", function() {
 
 })
 
-describe('nearleyc', function() {
+describe('nearleyc: example grammars', function() {
 
     it('calculator example', function() {
         var arith = compile(read("examples/calculator/arithmetic.ne"));
@@ -59,45 +59,40 @@ describe('nearleyc', function() {
         compile(read('test/grammars/indentation.ne'));
     });
 
-    it('nullable whitespace bug', function() {
-        var wsb = compile(read("test/grammars/whitespace.ne"));
-        expect(parse(wsb, "(x)")).toEqual(
-            [ [ [ [ '(', null, [ [ [ [ 'x' ] ] ] ], null, ')' ] ] ] ]);
-    });
-
     it('percent bug', function() {
         compile(read('test/grammars/percent.ne'));
     });
 
-    it('tokens', function() {
-        var tokc = compile(read("examples/token.ne"));
-        expect(parse(tokc, [123, 456, " ", 789])).toEqual([ [123, [ [ 456, " ", 789 ] ]] ]);
-    });
-
-    it('leo bug', function() {
-        var leo = compile(read("test/grammars/leobug.ne"));
-        expect(parse(leo, "baab")).toEqual(
-            [ [ 'b', [], 'a', [], 'a', [ 'b' ] ],
-            [ 'b', [], 'a', [], 'a', [ 'b', [] ] ] ]);
-    });
-
-    var json;
-    it('json example compiles', function() {
-        json = compile(read("examples/json.ne"));
-    });
-    it('json test1', function() {
-        var test1 = read('test/grammars/test1.json');
-        expect(parse(json, test1)).toEqual([JSON.parse(test1)]);
-    });
-    it('json test2', function() {
-        var test2 = read('test/grammars/test2.json');
-        expect(parse(json, test2)).toEqual([JSON.parse(test2)]);
-    });
-
-    it('tosh example', function() {
-        var tosh = compile(read("examples/tosh.ne"));
-        expect(parse(tosh, "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))"))
-            .toEqual([["setVar:to:","foo",["*",["*",2,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]],["-",1,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]]]]]);
+    it('json', function() {
+        const grammar = compile(read("examples/json.ne"));
+        expect(prettyPrint(grammar)).toEqual([
+            'json$subexpression$1 → object',
+            'json$subexpression$1 → array',
+            'json → _ json$subexpression$1 _',
+            'object → "{" _ "}"',
+            'object$ebnf$1 → ',
+            'object$ebnf$1$subexpression$1 → _ "," _ pair',
+            'object$ebnf$1 → object$ebnf$1 object$ebnf$1$subexpression$1',
+            'object → "{" _ pair object$ebnf$1 _ "}"',
+            'array → "[" _ "]"',
+            'array$ebnf$1 → ',
+            'array$ebnf$1$subexpression$1 → _ "," _ value',
+            'array$ebnf$1 → array$ebnf$1 array$ebnf$1$subexpression$1',
+            'array → "[" _ value array$ebnf$1 _ "]"',
+            'value → object',
+            'value → array',
+            'value → number',
+            'value → string',
+            'value → "true"',
+            'value → "false"',
+            'value → "null"',
+            'number → %number',
+            'string → %string',
+            'pair → key _ ":" _ value',
+            'key → string',
+            '_ → ',
+            '_ → %space',
+        ])
     });
 
     it('classic crontab', function() {
@@ -107,36 +102,6 @@ describe('nearleyc', function() {
         var crontabTest = read('test/grammars/classic_crontab.test');
         var crontabResults = read('test/grammars/classic_crontab.results');
         expect(parse(classicCrontab, crontabTest)).toEqual([JSON.parse(crontabResults)]);
-    });
-
-    it('parentheses', function() {
-        // Try compiling the grammar
-        var parentheses = compile(read("examples/parentheses.ne"));
-        var passCases = [
-            '()',
-            '[(){}<>]',
-            '[(((<>)()({})())(()())(())[])]',
-            '<<[([])]>([(<>[]{}{}<>())[{}[][]{}{}[]<>[]{}<>{}<>[]<>{}()][[][][]()()()]({})<[]>{(){}()<>}(<>[])]())({})>'
-        ];
-
-        for (let i in passCases) {
-            expect(parse(parentheses, passCases[i])).toEqual([true]);
-        }
-
-        var failCases = [
-            ' ',
-            '[}',
-            '[(){}><]',
-            '(((())))(()))'
-        ];
-
-        for (let i in failCases) {
-            expect(function() { parse(parentheses, failCases[i]); }).toThrow()
-        }
-
-        // These are invalid inputs but the parser will not complain
-        expect(parse(parentheses, '')).toEqual([]);
-        expect(parse(parentheses, '((((())))(())()')).toEqual([]);
     });
 
     it('case-insensitive strings', function() {
@@ -156,7 +121,7 @@ describe('nearleyc', function() {
 
 });
 
-describe('builtins', () => {
+describe('nearleyc: builtins', () => {
 
     it('generate includes id', () => {
         const source = nearleyc(`
@@ -178,7 +143,7 @@ describe('builtins', () => {
     })
 })
 
-describe('macros', () => {
+describe('nearleyc: macros', () => {
 
     it('seem to work', () => {
         // Matches "'Hello?' 'Hello?' 'Hello?'"
@@ -188,13 +153,13 @@ describe('macros', () => {
             main -> matchThree[inQuotes["Hello?"]]
         `)
 
-        expect(inspect(grammar)).toEqual([
-"main$macrocall$2$macrocall$2$string$1 → \"H\" \"e\" \"l\" \"l\" \"o\" \"?\"",
-            "main$macrocall$2$macrocall$2 → main$macrocall$2$macrocall$2$string$1",
-            "main$macrocall$2$macrocall$1 → \"'\" main$macrocall$2$macrocall$2 \"'\"",
-            "main$macrocall$2 → main$macrocall$2$macrocall$1",
-            "main$macrocall$1 → main$macrocall$2 \" \" main$macrocall$2 \" \" main$macrocall$2",
-            "main → main$macrocall$1",
+        expect(prettyPrint(grammar)).toEqual([
+            'main$macrocall$2$macrocall$2$string$1 → "H" "e" "l" "l" "o" "?"',
+            'main$macrocall$2$macrocall$2 → main$macrocall$2$macrocall$2$string$1',
+            'main$macrocall$2$macrocall$1 → "\'" main$macrocall$2$macrocall$2 "\'"',
+            'main$macrocall$2 → main$macrocall$2$macrocall$1',
+            'main$macrocall$1 → main$macrocall$2 " " main$macrocall$2 " " main$macrocall$2',
+            'main → main$macrocall$1',
         ])
     })
 


### PR DESCRIPTION
This:

* Adds some tests for macros (ref #290)
* Tries to split up the tests into tests for `nearleyc`--the compiler--and tests for the parsing algorithm.

The idea is to make each of the parser and nearleyc easier to refactor on their own.

@Hardmath123 Thoughts? :-)