### PR TITLE
Fix Typescript template

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -179,7 +179,7 @@ generate.ts = generate.typescript = function (parser, exportName) {
     output += "  reset: (chunk: string, info: any) => void;\n";
     output += "  next: () => Token | undefined;\n";
     output += "  save: () => any;\n";
-    output += "  formatError: (token: Token) => string;\n";
+    output += "  formatError: (token: Token, message?: string) => string;\n";
     output += "  has: (tokenType: string) => boolean\n";
     output += "};\n"
     output += "\n";


### PR DESCRIPTION
Fixes the Lexer typing for 'formatError' to agree with its actual use.