### PR TITLE
Add code formatter

### DIFF
--- a/bin/.eslintrc
+++ b/bin/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "node": true,
+    "commonjs": true,
+    "es6": false
+  },
+  "rules": {
+    "indent": [
+      "error",
+      4
+    ]
+  },
+  "extends": ["eslint:recommended"]
+}

--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -1,35 +1,38 @@
 #!/usr/bin/env node
 
 try {
-  var rr = require('railroad-diagrams');
-} catch(e) {
-  // optional dependency not fullfilled
-  console.log('Error: When you installed nearley, the dependency "railroad-diagrams" failed to install. Try running "npm install -g nearley" to re-install nearley. If that doesn\'t fix the problem, please file an issue on the nearley GitHub repository.')
-  process.exit(1)
+    var rr = require("railroad-diagrams");
+} catch (e) {
+    // optional dependency not fullfilled
+    console.log(
+        'Error: When you installed nearley, the dependency "railroad-diagrams" failed to install. Try running "npm install -g nearley" to re-install nearley. If that doesn\'t fix the problem, please file an issue on the nearley GitHub repository.'
+    );
+    process.exit(1);
 }
 
-var fs = require('fs');
-var path = require('path');
-var nomnom = require('nomnom');
+var fs = require("fs");
+var path = require("path");
+var nomnom = require("nomnom");
 
 var opts = nomnom
-    .script('nearley-railroad')
-    .option('file', {
+    .script("nearley-railroad")
+    .option("file", {
         position: 0,
         help: "A grammar .ne file (default stdin)"
     })
-    .option('out', {
-        abbr: 'o',
+    .option("out", {
+        abbr: "o",
         help: "File to output to (default stdout)."
     })
-    .option('version', {
-        abbr: 'v',
+    .option("version", {
+        abbr: "v",
         flag: true,
         help: "Print version and exit",
         callback: function() {
-            return require('../package.json').version;
+            return require("../package.json").version;
         }
-    }).parse();
+    })
+    .parse();
 
 var input = opts.file ? fs.createReadStream(opts.file) : process.stdin;
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
@@ -47,23 +50,23 @@ function railroad(grm) {
 
     var style = fs.readFileSync(
         path.join(
-            path.dirname(require.resolve('railroad-diagrams')),
-            'railroad-diagrams.css'
+            path.dirname(require.resolve("railroad-diagrams")),
+            "railroad-diagrams.css"
         )
     );
 
     var diagrams = Object.keys(rules).map(function(r) {
         return [
-          '<h1><code>' + r + '</code></h1>',
-          '<div>',
+            "<h1><code>" + r + "</code></h1>",
+            "<div>",
             diagram(r).toString(),
-          '</div>'
-        ].join('\n');
+            "</div>"
+        ].join("\n");
     });
 
     function diagram(name) {
         var selectedrules = rules[name];
-        var outer = {subexpression: selectedrules};
+        var outer = { subexpression: selectedrules };
 
         function renderTok(tok) {
             // ctx translated to correct position already
@@ -71,15 +74,15 @@ function railroad(grm) {
                 return new rr.Choice(0, tok.subexpression.map(renderTok));
             } else if (tok.ebnf) {
                 switch (tok.modifier) {
-                case ":+":
-                    return new rr.OneOrMore(renderTok(tok.ebnf));
-                    break;
-                case ":*":
-                    return new rr.ZeroOrMore(renderTok(tok.ebnf));
-                    break;
-                case ":?":
-                    return new rr.Optional(renderTok(tok.ebnf));
-                    break;
+                    case ":+":
+                        return new rr.OneOrMore(renderTok(tok.ebnf));
+                        break;
+                    case ":*":
+                        return new rr.ZeroOrMore(renderTok(tok.ebnf));
+                        break;
+                    case ":?":
+                        return new rr.Optional(renderTok(tok.ebnf));
+                        break;
                 }
             } else if (tok.literal) {
                 return new rr.Terminal(JSON.stringify(tok.literal));
@@ -89,7 +92,7 @@ function railroad(grm) {
                 return new rr.Comment("Pas implementé.");
             } else if (tok.tokens) {
                 return new rr.Sequence(tok.tokens.map(renderTok));
-            } else if (typeof(tok) === 'string') {
+            } else if (typeof tok === "string") {
                 return new rr.NonTerminal(tok);
             } else if (tok.constructor === RegExp) {
                 return new rr.Terminal(tok.toString());
@@ -102,31 +105,32 @@ function railroad(grm) {
     }
 
     return [
-      '<!DOCTYPE html>',
-      '<html>',
-        '<head>',
-          '<meta charset="UTF-8">',
-          '<style type="text/css">',
-            style.toString(),
-          '</style>',
-        '</head>',
-        '<body>',
-          diagrams.join('\n'),
-        '</body>',
-      '</html>'
-    ].join('\n');
+        "<!DOCTYPE html>",
+        "<html>",
+        "<head>",
+        '<meta charset="UTF-8">',
+        '<style type="text/css">',
+        style.toString(),
+        "</style>",
+        "</head>",
+        "<body>",
+        diagrams.join("\n"),
+        "</body>",
+        "</html>"
+    ].join("\n");
 }
 
-var nearley = require('../lib/nearley.js');
-var StreamWrapper = require('../lib/stream.js');
-var parserGrammar = new require('../lib/nearley-language-bootstrapped.js');
-var parser = new nearley.Parser(parserGrammar.ParserRules, parserGrammar.ParserStart);
-input
-    .pipe(new StreamWrapper(parser))
-    .on('finish', function() {
-        if (parser.results[0]) {
-            output.write(railroad(parser.results[0]));
-        } else {
-            process.stderr.write('SyntaxError: unexpected EOF\n');
-        }
-    });
+var nearley = require("../lib/nearley.js");
+var StreamWrapper = require("../lib/stream.js");
+var parserGrammar = new require("../lib/nearley-language-bootstrapped.js");
+var parser = new nearley.Parser(
+    parserGrammar.ParserRules,
+    parserGrammar.ParserStart
+);
+input.pipe(new StreamWrapper(parser)).on("finish", function() {
+    if (parser.results[0]) {
+        output.write(railroad(parser.results[0]));
+    } else {
+        process.stderr.write("SyntaxError: unexpected EOF\n");
+    }
+});

--- a/bin/nearley-test.js
+++ b/bin/nearley-test.js
@@ -4,84 +4,87 @@
    or, node bin/nearleythere.js examples/js/AycockHorspool.js --input "aa" 
  */
 
-var fs = require('fs');
-var nearley = require('../lib/nearley.js');
-var nomnom = require('nomnom');
-var StreamWrapper = require('../lib/stream.js');
+var fs = require("fs");
+var nearley = require("../lib/nearley.js");
+var nomnom = require("nomnom");
+var StreamWrapper = require("../lib/stream.js");
 
 var opts = nomnom
-    .script('nearley-test')
-    .option('file', {
+    .script("nearley-test")
+    .option("file", {
         position: 0,
         help: "A grammar .js file",
-        required: true,
+        required: true
     })
-    .option('input', {
-        abbr: 'i',
+    .option("input", {
+        abbr: "i",
         help: "An input string to parse (if not provided then read from stdin)",
-        type: 'string',
+        type: "string"
     })
-    .option('start', {
-        abbr: 's',
-        help: "An optional start symbol (if not provided then use the parser start symbol)",
+    .option("start", {
+        abbr: "s",
+        help:
+            "An optional start symbol (if not provided then use the parser start symbol)"
     })
-    .option('out', {
-        abbr: 'o',
-        help: "File to output to (defaults to stdout)",
+    .option("out", {
+        abbr: "o",
+        help: "File to output to (defaults to stdout)"
     })
-    .option('quiet', {
-        abbr: 'q',
+    .option("quiet", {
+        abbr: "q",
         flag: true,
-        help: "Output parse results only (hide Earley table)",
+        help: "Output parse results only (hide Earley table)"
     })
-    .option('version', {
-        abbr: 'v',
+    .option("version", {
+        abbr: "v",
         flag: true,
         help: "Print version and exit",
         callback: function() {
-            return require('../package.json').version;
+            return require("../package.json").version;
         }
     })
     .parse();
 
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
-var filename = require('path').resolve(opts.file);
+var filename = require("path").resolve(opts.file);
 var grammar = nearley.Grammar.fromCompiled(require(filename));
-if (opts.start) grammar.start = opts.start
+if (opts.start) grammar.start = opts.start;
 var parser = new nearley.Parser(grammar, {
-    keepHistory: true,
+    keepHistory: true
 });
 
-var writeTable = function (writeStream, parser) {
+var writeTable = function(writeStream, parser) {
     writeStream.write("Table length: " + parser.table.length + "\n");
     writeStream.write("Number of parses: " + parser.results.length + "\n");
     writeStream.write("Parse Charts");
-    parser.table.forEach(function (column, index) {
+    parser.table.forEach(function(column, index) {
         writeStream.write("\nChart: " + index++ + "\n");
         var stateNumber = 0;
-        column.states.forEach(function (state, stateIndex) {
+        column.states.forEach(function(state, stateIndex) {
             writeStream.write(stateIndex + ": " + state.toString() + "\n");
-        })
-    })
-    writeStream.write("\n\nParse results: \n");
-}
-
-var writeResults = function (writeStream, parser) {
-    writeStream.write(require('util').inspect(parser.results, {colors: !opts.quiet, depth: null}));
-    writeStream.write("\n");
-}
-
-if (typeof(opts.input) === "undefined") {
-    process.stdin
-        .pipe(new StreamWrapper(parser))
-        .on('finish', function() {
-            if (!opts.quiet) writeTable(output, parser);
-            writeResults(output, parser);
         });
+    });
+    writeStream.write("\n\nParse results: \n");
+};
+
+var writeResults = function(writeStream, parser) {
+    writeStream.write(
+        require("util").inspect(parser.results, {
+            colors: !opts.quiet,
+            depth: null
+        })
+    );
+    writeStream.write("\n");
+};
+
+if (typeof opts.input === "undefined") {
+    process.stdin.pipe(new StreamWrapper(parser)).on("finish", function() {
+        if (!opts.quiet) writeTable(output, parser);
+        writeResults(output, parser);
+    });
 } else {
     parser.feed(opts.input);
     if (!opts.quiet) writeTable(output, parser);
     writeResults(output, parser);
 }
-

--- a/bin/nearley-unparse.js
+++ b/bin/nearley-unparse.js
@@ -1,48 +1,50 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
-var nearley = require('../lib/nearley.js');
-var nomnom = require('nomnom');
-var randexp = require('randexp');
+var fs = require("fs");
+var nearley = require("../lib/nearley.js");
+var nomnom = require("nomnom");
+var randexp = require("randexp");
 
 var opts = nomnom
-    .script('nearley-unparse')
-    .option('file', {
+    .script("nearley-unparse")
+    .option("file", {
         position: 0,
         help: "A grammar .js file",
-        required: true,
+        required: true
     })
-    .option('start', {
-        abbr: 's',
-        help: "An optional start symbol (if not provided then use the parser start symbol)",
+    .option("start", {
+        abbr: "s",
+        help:
+            "An optional start symbol (if not provided then use the parser start symbol)"
     })
-    .option('count', {
-        abbr: 'n',
-        help: 'The number of samples to generate (separated by \\n).',
+    .option("count", {
+        abbr: "n",
+        help: "The number of samples to generate (separated by \\n).",
         default: 1
     })
-    .option('depth', {
-        abbr: 'd',
-        help: 'The depth bound of each sample. Defaults to -1, which means "unbounded".',
+    .option("depth", {
+        abbr: "d",
+        help:
+            'The depth bound of each sample. Defaults to -1, which means "unbounded".',
         default: -1
     })
-    .option('out', {
-        abbr: 'o',
-        help: "File to output to (defaults to stdout)",
+    .option("out", {
+        abbr: "o",
+        help: "File to output to (defaults to stdout)"
     })
-    .option('version', {
-        abbr: 'v',
+    .option("version", {
+        abbr: "v",
         flag: true,
         help: "Print version and exit",
         callback: function() {
-            return require('../package.json').version;
+            return require("../package.json").version;
         }
     })
     .parse();
 
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
-var grammar = new require(require('path').resolve(opts.file));
+var grammar = new require(require("path").resolve(opts.file));
 
 function gen(grammar, name) {
     // The first-generation generator. It just spews out stuff randomly, and is
@@ -53,19 +55,18 @@ function gen(grammar, name) {
 
     while (stack.length > 0) {
         var currentname = stack.pop();
-        if (typeof(currentname) === 'string') {
+        if (typeof currentname === "string") {
             var goodrules = grammar.ParserRules.filter(function(x) {
                 return x.name === currentname;
             });
             if (goodrules.length > 0) {
-                var chosen = goodrules[
-                    Math.floor(Math.random()*goodrules.length)
-                ];
-                for (var i=chosen.symbols.length-1; i>=0; i--) {
+                var chosen =
+                    goodrules[Math.floor(Math.random() * goodrules.length)];
+                for (var i = chosen.symbols.length - 1; i >= 0; i--) {
                     stack.push(chosen.symbols[i]);
                 }
             } else {
-                throw new Error("Nothing matches rule: "+currentname+"!");
+                throw new Error("Nothing matches rule: " + currentname + "!");
             }
         } else if (currentname.test) {
             var c = new randexp(currentname).gen();
@@ -92,7 +93,7 @@ function gen2(grammar, name, depth) {
     function synth_nt(name, depth) {
         var good_rules = [];
         var min_min_depth = Infinity;
-        for (var i=0; i<rules.length; i++) {
+        for (var i = 0; i < rules.length; i++) {
             min_depths_rule = [];
             var size = min_depth_rule(i, []);
             if (rules[i].name === name) {
@@ -103,20 +104,23 @@ function gen2(grammar, name, depth) {
             }
         }
         if (good_rules.length === 0) {
-            throw ("No strings in your grammar have depth "+depth+" (and " +
-                   "none are shallower). Try increasing -d to at least "+
-                   (min_min_depth+1) + ".");
+            throw "No strings in your grammar have depth " +
+                depth +
+                " (and " +
+                "none are shallower). Try increasing -d to at least " +
+                (min_min_depth + 1) +
+                ".";
         }
 
-        var r = good_rules[Math.floor(Math.random()*good_rules.length)];
+        var r = good_rules[Math.floor(Math.random() * good_rules.length)];
         return synth_rule(r, depth);
     }
     function synth_rule(idx, depth) {
         var ret = "";
-        for (var i=0; i<rules[idx].symbols.length; i++) {
+        for (var i = 0; i < rules[idx].symbols.length; i++) {
             var tok = rules[idx].symbols[i];
-            if (typeof(tok) === 'string') {
-                ret += synth_nt(tok, depth-1);
+            if (typeof tok === "string") {
+                ret += synth_nt(tok, depth - 1);
             } else if (tok.test) {
                 ret += new randexp(tok).gen();
             } else if (tok.literal) {
@@ -130,7 +134,7 @@ function gen2(grammar, name, depth) {
             return +Infinity;
         }
         var d = +Infinity;
-        for (var i=0; i<rules.length; i++) {
+        for (var i = 0; i < rules.length; i++) {
             if (rules[i].name === name) {
                 d = Math.min(d, min_depth_rule(i, [name].concat(visited)));
             }
@@ -141,10 +145,10 @@ function gen2(grammar, name, depth) {
         if (min_depths_rule[idx] !== undefined) return min_depths_rule[idx];
 
         var d = 1;
-        for (var i=0; i<rules[idx].symbols.length; i++) {
+        for (var i = 0; i < rules[idx].symbols.length; i++) {
             var tok = rules[idx].symbols[i];
-            if (typeof(tok) === 'string') {
-                d = Math.max(d, 1+min_depth_nt(tok, visited));
+            if (typeof tok === "string") {
+                d = Math.max(d, 1 + min_depth_nt(tok, visited));
             }
         }
         min_depths_rule[idx] = d;
@@ -155,14 +159,18 @@ function gen2(grammar, name, depth) {
     return ret;
 }
 
-
-
 // the main loop
-for (var i=0; i<parseInt(opts.count); i++) {
+for (var i = 0; i < parseInt(opts.count); i++) {
     if (opts.depth === -1) {
         gen(grammar, opts.start ? opts.start : grammar.ParserStart);
     } else {
-        output.write(gen2(grammar, opts.start ? opts.start : grammar.ParserStart, opts.depth));
+        output.write(
+            gen2(
+                grammar,
+                opts.start ? opts.start : grammar.ParserStart,
+                opts.depth
+            )
+        );
     }
     if (opts.count > 1) output.write("\n");
 }

--- a/bin/nearleyc.js
+++ b/bin/nearleyc.js
@@ -1,63 +1,63 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
-var nearley = require('../lib/nearley.js');
-var nomnom = require('nomnom');
-var Compile = require('../lib/compile.js');
-var StreamWrapper = require('../lib/stream.js');
+var fs = require("fs");
+var nearley = require("../lib/nearley.js");
+var nomnom = require("nomnom");
+var Compile = require("../lib/compile.js");
+var StreamWrapper = require("../lib/stream.js");
 
 var opts = nomnom
-    .script('nearleyc')
-    .option('file', {
+    .script("nearleyc")
+    .option("file", {
         position: 0,
-        help: "An input .ne file (if not provided then read from stdin)",
+        help: "An input .ne file (if not provided then read from stdin)"
     })
-    .option('out', {
-        abbr: 'o',
-        help: "File to output to (defaults to stdout)",
+    .option("out", {
+        abbr: "o",
+        help: "File to output to (defaults to stdout)"
     })
-    .option('export', {
-        abbr: 'e',
+    .option("export", {
+        abbr: "e",
         help: "Variable to set the parser to",
         default: "grammar"
     })
-    .option('quiet', {
-        abbr: 'q',
+    .option("quiet", {
+        abbr: "q",
         flag: true,
         help: "Suppress the linter."
     })
-    .option('nojs', {
+    .option("nojs", {
         flag: true,
         default: false,
         help: "Don't compile postprocessors (for testing)."
     })
-    .option('version', {
-        abbr: 'v',
+    .option("version", {
+        abbr: "v",
         flag: true,
         help: "Print version and exit",
         callback: function() {
-            return require('../package.json').version;
+            return require("../package.json").version;
         }
     })
     .parse();
 
-var version = require('../package.json').version;
+var version = require("../package.json").version;
 
 var input = opts.file ? fs.createReadStream(opts.file) : process.stdin;
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
-var parserGrammar = nearley.Grammar.fromCompiled(require('../lib/nearley-language-bootstrapped.js'));
+var parserGrammar = nearley.Grammar.fromCompiled(
+    require("../lib/nearley-language-bootstrapped.js")
+);
 var parser = new nearley.Parser(parserGrammar);
-var generate = require('../lib/generate.js');
-var lint = require('../lib/lint.js');
+var generate = require("../lib/generate.js");
+var lint = require("../lib/lint.js");
 
-input
-    .pipe(new StreamWrapper(parser))
-    .on('finish', function() {
-        var c = Compile(
-            parser.results[0],
-            Object.assign({version: version}, opts)
-        );
-        if (!opts.quiet) lint(c, {'out': process.stderr, 'version': version});
-        output.write(generate(c, opts.export));
-    });
+input.pipe(new StreamWrapper(parser)).on("finish", function() {
+    var c = Compile(
+        parser.results[0],
+        Object.assign({ version: version }, opts)
+    );
+    if (!opts.quiet) lint(c, { out: process.stderr, version: version });
+    output.write(generate(c, opts.export));
+});

--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": false
+  },
+  "rules": {
+    "indent": [
+      "error",
+      4
+    ]
+  },
+  "extends": ["eslint:recommended"]
+}

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,202 +1,221 @@
 (function(root, factory) {
-    if (typeof module === 'object' && module.exports) {
-        module.exports = factory(require('./nearley'));
+    if (typeof module === "object" && module.exports) {
+        module.exports = factory(require("./nearley"));
     } else {
         root.Compile = factory(root.nearley);
     }
-}(this, function(nearley) {
+})(this, function(nearley) {
+    function Compile(structure, opts) {
+        var unique = uniquer();
+        if (!opts.alreadycompiled) {
+            opts.alreadycompiled = [];
+        }
 
-function Compile(structure, opts) {
-    var unique = uniquer();
-    if (!opts.alreadycompiled) {
-        opts.alreadycompiled = [];
-    }
+        var result = {
+            rules: [],
+            body: [], // @directives list
+            customTokens: [], // %tokens
+            config: {}, // @config value
+            macros: {},
+            start: "",
+            version: opts.version || "unknown"
+        };
 
-    var result = {
-        rules: [],
-        body: [], // @directives list
-        customTokens: [], // %tokens
-        config: {}, // @config value
-        macros: {},
-        start: '',
-        version: opts.version || 'unknown'
-    };
-
-    for (var i = 0; i < structure.length; i++) {
-        var productionRule = structure[i];
-        if (productionRule.body) {
-            // This isn't a rule, it's an @directive.
-            if (!opts.nojs) {
-                result.body.push(productionRule.body);
-            }
-        } else if (productionRule.include) {
-            // Include file
-            var path;
-            if (!productionRule.builtin) {
-                path = require('path').resolve(
-                    opts.file ? require('path').dirname(opts.file) : process.cwd(),
-                    productionRule.include
-                );
+        for (var i = 0; i < structure.length; i++) {
+            var productionRule = structure[i];
+            if (productionRule.body) {
+                // This isn't a rule, it's an @directive.
+                if (!opts.nojs) {
+                    result.body.push(productionRule.body);
+                }
+            } else if (productionRule.include) {
+                // Include file
+                var path;
+                if (!productionRule.builtin) {
+                    path = require("path").resolve(
+                        opts.file
+                            ? require("path").dirname(opts.file)
+                            : process.cwd(),
+                        productionRule.include
+                    );
+                } else {
+                    path = require("path").resolve(
+                        __dirname,
+                        "../builtin/",
+                        productionRule.include
+                    );
+                }
+                if (opts.alreadycompiled.indexOf(path) === -1) {
+                    opts.alreadycompiled.push(path);
+                    var f = require("fs")
+                        .readFileSync(path)
+                        .toString();
+                    var parserGrammar = nearley.Grammar.fromCompiled(
+                        require("./nearley-language-bootstrapped.js")
+                    );
+                    var parser = new nearley.Parser(parserGrammar);
+                    parser.feed(f);
+                    var c = Compile(parser.results[0], {
+                        file: path,
+                        __proto__: opts
+                    });
+                    result.rules = result.rules.concat(c.rules);
+                    result.body = result.body.concat(c.body);
+                    result.customTokens = result.customTokens.concat(
+                        c.customTokens
+                    );
+                    Object.keys(c.config).forEach(function(k) {
+                        result.config[k] = c.config[k];
+                    });
+                    Object.keys(c.macros).forEach(function(k) {
+                        result.macros[k] = c.macros[k];
+                    });
+                }
+            } else if (productionRule.macro) {
+                result.macros[productionRule.macro] = {
+                    args: productionRule.args,
+                    exprs: productionRule.exprs
+                };
+            } else if (productionRule.config) {
+                // This isn't a rule, it's an @config.
+                result.config[productionRule.config] = productionRule.value;
             } else {
-                path = require('path').resolve(
-                    __dirname,
-                    '../builtin/',
-                    productionRule.include
-                );
-            }
-            if (opts.alreadycompiled.indexOf(path) === -1) {
-                opts.alreadycompiled.push(path);
-                var f = require('fs').readFileSync(path).toString();
-                var parserGrammar = nearley.Grammar.fromCompiled(require('./nearley-language-bootstrapped.js'));
-                var parser = new nearley.Parser(parserGrammar);
-                parser.feed(f);
-                var c = Compile(parser.results[0], {file: path, __proto__:opts});
-                result.rules = result.rules.concat(c.rules);
-                result.body  = result.body.concat(c.body);
-                result.customTokens = result.customTokens.concat(c.customTokens);
-                Object.keys(c.config).forEach(function(k) {
-                    result.config[k] = c.config[k];
-                });
-                Object.keys(c.macros).forEach(function(k) {
-                    result.macros[k] = c.macros[k];
-                });
-            }
-        } else if (productionRule.macro) {
-            result.macros[productionRule.macro] = {
-                'args': productionRule.args,
-                'exprs': productionRule.exprs
-            };
-        } else if (productionRule.config) {
-            // This isn't a rule, it's an @config.
-            result.config[productionRule.config] = productionRule.value
-        } else {
-            produceRules(productionRule.name, productionRule.rules, {});
-            if (!result.start) {
-                result.start = productionRule.name;
+                produceRules(productionRule.name, productionRule.rules, {});
+                if (!result.start) {
+                    result.start = productionRule.name;
+                }
             }
         }
-    }
 
-    return result;
+        return result;
 
-    function produceRules(name, rules, env) {
-        for (var i = 0; i < rules.length; i++) {
-            var rule = buildRule(name, rules[i], env);
-            if (opts.nojs) {
-                rule.postprocess = null;
-            }
-            result.rules.push(rule);
-        }
-    }
-
-    function buildRule(ruleName, rule, env) {
-        var tokens = [];
-        for (var i = 0; i < rule.tokens.length; i++) {
-            var token = buildToken(ruleName, rule.tokens[i], env);
-            if (token !== null) {
-                tokens.push(token);
+        function produceRules(name, rules, env) {
+            for (var i = 0; i < rules.length; i++) {
+                var rule = buildRule(name, rules[i], env);
+                if (opts.nojs) {
+                    rule.postprocess = null;
+                }
+                result.rules.push(rule);
             }
         }
-        return new nearley.Rule(
-            ruleName,
-            tokens,
-            rule.postprocess
-        );
-    }
 
-    function buildToken(ruleName, token, env) {
-        if (typeof token === 'string') {
-            if (token === 'null') {
-                return null;
+        function buildRule(ruleName, rule, env) {
+            var tokens = [];
+            for (var i = 0; i < rule.tokens.length; i++) {
+                var token = buildToken(ruleName, rule.tokens[i], env);
+                if (token !== null) {
+                    tokens.push(token);
+                }
             }
-            return token;
+            return new nearley.Rule(ruleName, tokens, rule.postprocess);
         }
 
-        if (token instanceof RegExp) {
-            return token;
-        }
-
-        if (token.literal) {
-            if (!token.literal.length) {
-                return null;
-            }
-            if (token.literal.length === 1 || result.config.lexer) {
+        function buildToken(ruleName, token, env) {
+            if (typeof token === "string") {
+                if (token === "null") {
+                    return null;
+                }
                 return token;
             }
-            return buildStringToken(ruleName, token, env);
-        }
-        if (token.token) {
-            if (result.config.lexer) {
-                var name = token.token;
-                if (result.customTokens.indexOf(name) === -1) {
-                    result.customTokens.push(name);
+
+            if (token instanceof RegExp) {
+                return token;
+            }
+
+            if (token.literal) {
+                if (!token.literal.length) {
+                    return null;
                 }
-                var expr = result.config.lexer + ".has(" + JSON.stringify(name) + ") ? {type: " + JSON.stringify(name) + "} : " + name;
-                return {token: "(" + expr + ")"};
+                if (token.literal.length === 1 || result.config.lexer) {
+                    return token;
+                }
+                return buildStringToken(ruleName, token, env);
             }
-            return token;
+            if (token.token) {
+                if (result.config.lexer) {
+                    var name = token.token;
+                    if (result.customTokens.indexOf(name) === -1) {
+                        result.customTokens.push(name);
+                    }
+                    var expr =
+                        result.config.lexer +
+                        ".has(" +
+                        JSON.stringify(name) +
+                        ") ? {type: " +
+                        JSON.stringify(name) +
+                        "} : " +
+                        name;
+                    return { token: "(" + expr + ")" };
+                }
+                return token;
+            }
+
+            if (token.subexpression) {
+                return buildSubExpressionToken(ruleName, token, env);
+            }
+
+            if (token.ebnf) {
+                return buildEBNFToken(ruleName, token, env);
+            }
+
+            if (token.macrocall) {
+                return buildMacroCallToken(ruleName, token, env);
+            }
+
+            if (token.mixin) {
+                if (env[token.mixin]) {
+                    return buildToken(ruleName, env[token.mixin], env);
+                } else {
+                    throw new Error("Unbound variable: " + token.mixin);
+                }
+            }
+
+            throw new Error("unrecognized token: " + JSON.stringify(token));
         }
 
-        if (token.subexpression) {
-            return buildSubExpressionToken(ruleName, token, env);
+        function buildStringToken(ruleName, token, env) {
+            var newname = unique(ruleName + "$string");
+            produceRules(
+                newname,
+                [
+                    {
+                        tokens: token.literal
+                            .split("")
+                            .map(function charLiteral(d) {
+                                return {
+                                    literal: d
+                                };
+                            }),
+                        postprocess: { builtin: "joiner" }
+                    }
+                ],
+                env
+            );
+            return newname;
         }
 
-        if (token.ebnf) {
-            return buildEBNFToken(ruleName, token, env);
+        function buildSubExpressionToken(ruleName, token, env) {
+            var data = token.subexpression;
+            var name = unique(ruleName + "$subexpression");
+            //structure.push({"name": name, "rules": data});
+            produceRules(name, data, env);
+            return name;
         }
 
-        if (token.macrocall) {
-            return buildMacroCallToken(ruleName, token, env);
-        }
-
-        if (token.mixin) {
-            if (env[token.mixin]) {
-                return buildToken(ruleName, env[token.mixin], env);
-            } else {
-                throw new Error("Unbound variable: " + token.mixin);
+        function buildEBNFToken(ruleName, token, env) {
+            switch (token.modifier) {
+                case ":+":
+                    return buildEBNFPlus(ruleName, token, env);
+                case ":*":
+                    return buildEBNFStar(ruleName, token, env);
+                case ":?":
+                    return buildEBNFOpt(ruleName, token, env);
             }
         }
 
-        throw new Error("unrecognized token: " + JSON.stringify(token));
-    }
-
-    function buildStringToken(ruleName, token, env) {
-        var newname = unique(ruleName + "$string");
-        produceRules(newname, [
-            {
-                tokens: token.literal.split("").map(function charLiteral(d) {
-                    return {
-                        literal: d
-                    };
-                }),
-                postprocess: {builtin: "joiner"}
-            }
-        ], env);
-        return newname;
-    }
-
-    function buildSubExpressionToken(ruleName, token, env) {
-        var data = token.subexpression;
-        var name = unique(ruleName + "$subexpression");
-        //structure.push({"name": name, "rules": data});
-        produceRules(name, data, env);
-        return name;
-    }
-
-    function buildEBNFToken(ruleName, token, env) {
-        switch (token.modifier) {
-            case ":+":
-                return buildEBNFPlus(ruleName, token, env);
-            case ":*":
-                return buildEBNFStar(ruleName, token, env);
-            case ":?":
-                return buildEBNFOpt(ruleName, token, env);
-        }
-    }
-
-    function buildEBNFPlus(ruleName, token, env) {
-        var name = unique(ruleName + "$ebnf");
-        /*
+        function buildEBNFPlus(ruleName, token, env) {
+            var name = unique(ruleName + "$ebnf");
+            /*
         structure.push({
             name: name,
             rules: [{
@@ -207,21 +226,25 @@ function Compile(structure, opts) {
             }]
         });
         */
-        produceRules(name,
-            [{
-                tokens: [token.ebnf],
-            }, {
-                tokens: [name, token.ebnf],
-                postprocess: {builtin: "arrpush"}
-            }],
-            env
-        );
-        return name;
-    }
+            produceRules(
+                name,
+                [
+                    {
+                        tokens: [token.ebnf]
+                    },
+                    {
+                        tokens: [name, token.ebnf],
+                        postprocess: { builtin: "arrpush" }
+                    }
+                ],
+                env
+            );
+            return name;
+        }
 
-    function buildEBNFStar(ruleName, token, env) {
-        var name = unique(ruleName + "$ebnf");
-        /*
+        function buildEBNFStar(ruleName, token, env) {
+            var name = unique(ruleName + "$ebnf");
+            /*
         structure.push({
             name: name,
             rules: [{
@@ -232,21 +255,25 @@ function Compile(structure, opts) {
             }]
         });
         */
-        produceRules(name,
-            [{
-                tokens: [],
-            }, {
-                tokens: [name, token.ebnf],
-                postprocess: {builtin: "arrpush"}
-            }],
-            env
-        );
-        return name;
-    }
+            produceRules(
+                name,
+                [
+                    {
+                        tokens: []
+                    },
+                    {
+                        tokens: [name, token.ebnf],
+                        postprocess: { builtin: "arrpush" }
+                    }
+                ],
+                env
+            );
+            return name;
+        }
 
-    function buildEBNFOpt(ruleName, token, env) {
-        var name = unique(ruleName + "$ebnf");
-        /*
+        function buildEBNFOpt(ruleName, token, env) {
+            var name = unique(ruleName + "$ebnf");
+            /*
         structure.push({
             name: name,
             rules: [{
@@ -258,50 +285,53 @@ function Compile(structure, opts) {
             }]
         });
         */
-        produceRules(name,
-            [{
-                tokens: [token.ebnf],
-                postprocess: {builtin: "id"}
-            }, {
-                tokens: [],
-                postprocess: {builtin: "nuller"}
-            }],
-            env
-        );
-        return name;
+            produceRules(
+                name,
+                [
+                    {
+                        tokens: [token.ebnf],
+                        postprocess: { builtin: "id" }
+                    },
+                    {
+                        tokens: [],
+                        postprocess: { builtin: "nuller" }
+                    }
+                ],
+                env
+            );
+            return name;
+        }
+
+        function buildMacroCallToken(ruleName, token, env) {
+            var name = unique(ruleName + "$macrocall");
+            var macro = result.macros[token.macrocall];
+            if (!macro) {
+                throw new Error("Unkown macro: " + token.macrocall);
+            }
+            if (macro.args.length !== token.args.length) {
+                throw new Error("Argument count mismatch.");
+            }
+            var newenv = { __proto__: env };
+            for (var i = 0; i < macro.args.length; i++) {
+                var argrulename = unique(ruleName + "$macrocall");
+                newenv[macro.args[i]] = argrulename;
+                produceRules(argrulename, [token.args[i]], env);
+                //structure.push({"name": argrulename, "rules":[token.args[i]]});
+                //buildRule(name, token.args[i], env);
+            }
+            produceRules(name, macro.exprs, newenv);
+            return name;
+        }
     }
 
-    function buildMacroCallToken(ruleName, token, env) {
-        var name = unique(ruleName + "$macrocall");
-        var macro = result.macros[token.macrocall];
-        if (!macro) {
-            throw new Error("Unkown macro: "+token.macrocall);
+    function uniquer() {
+        var uns = {};
+        return unique;
+        function unique(name) {
+            var un = (uns[name] = (uns[name] || 0) + 1);
+            return name + "$" + un;
         }
-        if (macro.args.length !== token.args.length) {
-            throw new Error("Argument count mismatch.");
-        }
-        var newenv = {__proto__: env};
-        for (var i=0; i<macro.args.length; i++) {
-            var argrulename = unique(ruleName + "$macrocall");
-            newenv[macro.args[i]] = argrulename;
-            produceRules(argrulename, [token.args[i]], env);
-            //structure.push({"name": argrulename, "rules":[token.args[i]]});
-            //buildRule(name, token.args[i], env);
-        }
-        produceRules(name, macro.exprs, newenv);
-        return name;
     }
-}
 
-function uniquer() {
-    var uns = {};
-    return unique;
-    function unique(name) {
-        var un = uns[name] = (uns[name] || 0) + 1;
-        return name + '$' + un;
-    }
-}
-
-return Compile;
-
-}));
+    return Compile;
+});

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,212 +1,272 @@
 (function(root, factory) {
-    if (typeof module === 'object' && module.exports) {
-        module.exports = factory(require('./nearley'));
+    if (typeof module === "object" && module.exports) {
+        module.exports = factory(require("./nearley"));
     } else {
         root.generate = factory(root.nearley);
     }
-}(this, function(nearley) {
-
-function serializeRules(rules, builtinPostprocessors) {
-    return "[\n    " + rules.map(function(rule) {
-      return serializeRule(rule, builtinPostprocessors);
-    }).join(",\n    ") + "\n]";
-}
-
-function dedentFunc(func) {
-    var lines = func.toString().split(/\n/);
-
-    if (lines.length === 1) {
-        return [lines[0].replace(/^\s+|\s+$/g, '')];
+})(this, function(nearley) {
+    function serializeRules(rules, builtinPostprocessors) {
+        return (
+            "[\n    " +
+            rules
+                .map(function(rule) {
+                    return serializeRule(rule, builtinPostprocessors);
+                })
+                .join(",\n    ") +
+            "\n]"
+        );
     }
 
-    var indent = null;
-    var tail = lines.slice(1);
-    for (var i = 0; i < tail.length; i++) {
-        var match = /^\s*/.exec(tail[i]);
-        if (match && match[0].length !== tail[i].length) {
-            if (indent === null ||
-                match[0].length < indent.length) {
-                indent = match[0];
+    function dedentFunc(func) {
+        var lines = func.toString().split(/\n/);
+
+        if (lines.length === 1) {
+            return [lines[0].replace(/^\s+|\s+$/g, "")];
+        }
+
+        var indent = null;
+        var tail = lines.slice(1);
+        for (var i = 0; i < tail.length; i++) {
+            var match = /^\s*/.exec(tail[i]);
+            if (match && match[0].length !== tail[i].length) {
+                if (indent === null || match[0].length < indent.length) {
+                    indent = match[0];
+                }
             }
         }
-    }
 
-    if (indent === null) {
-        return lines;
-    }
-
-    return lines.map(function dedent(line) {
-        if (line.slice(0, indent.length) === indent) {
-            return line.slice(indent.length);
-        }
-        return line;
-    });
-}
-
-function tabulateString(string, indent, options) {
-    var lines;
-    if(Array.isArray(string)) {
-      lines = string;
-    } else {
-      lines = string.toString().split('\n');
-    }
-
-    options = options || {};
-    tabulated = lines.map(function addIndent(line, i) {
-        var shouldIndent = true;
-
-        if(i == 0 && !options.indentFirst) {
-          shouldIndent = false;
+        if (indent === null) {
+            return lines;
         }
 
-        if(shouldIndent) {
-            return indent + line;
-        } else {
+        return lines.map(function dedent(line) {
+            if (line.slice(0, indent.length) === indent) {
+                return line.slice(indent.length);
+            }
             return line;
+        });
+    }
+
+    function tabulateString(string, indent, options) {
+        var lines;
+        if (Array.isArray(string)) {
+            lines = string;
+        } else {
+            lines = string.toString().split("\n");
         }
-    }).join('\n');
 
-    return tabulated;
-}
+        options = options || {};
+        tabulated = lines
+            .map(function addIndent(line, i) {
+                var shouldIndent = true;
 
-function serializeSymbol(s) {
-    if (s instanceof RegExp) {
-        return s.toString();
-    } else if (s.token) {
-        return s.token;
-    } else {
-        return JSON.stringify(s);
+                if (i == 0 && !options.indentFirst) {
+                    shouldIndent = false;
+                }
+
+                if (shouldIndent) {
+                    return indent + line;
+                } else {
+                    return line;
+                }
+            })
+            .join("\n");
+
+        return tabulated;
     }
-}
 
-function serializeRule(rule, builtinPostprocessors) {
-    var ret = '{';
-    ret += '"name": ' + JSON.stringify(rule.name);
-    ret += ', "symbols": [' + rule.symbols.map(serializeSymbol).join(', ') + ']';
-    if (rule.postprocess) {
-        if(rule.postprocess.builtin) {
-            rule.postprocess = builtinPostprocessors[rule.postprocess.builtin];
+    function serializeSymbol(s) {
+        if (s instanceof RegExp) {
+            return s.toString();
+        } else if (s.token) {
+            return s.token;
+        } else {
+            return JSON.stringify(s);
         }
-        ret += ', "postprocess": ' + tabulateString(dedentFunc(rule.postprocess), '        ', {indentFirst: false});
-    }
-    ret += '}';
-    return ret;
-}
-
-var generate = function (parser, exportName) {
-    if(!parser.config.preprocessor) {
-        parser.config.preprocessor = "_default";
     }
 
-    if(!generate[parser.config.preprocessor]) {
-        throw new Error("No such preprocessor: " + parser.config.preprocessor)
+    function serializeRule(rule, builtinPostprocessors) {
+        var ret = "{";
+        ret += '"name": ' + JSON.stringify(rule.name);
+        ret +=
+            ', "symbols": [' +
+            rule.symbols.map(serializeSymbol).join(", ") +
+            "]";
+        if (rule.postprocess) {
+            if (rule.postprocess.builtin) {
+                rule.postprocess =
+                    builtinPostprocessors[rule.postprocess.builtin];
+            }
+            ret +=
+                ', "postprocess": ' +
+                tabulateString(dedentFunc(rule.postprocess), "        ", {
+                    indentFirst: false
+                });
+        }
+        ret += "}";
+        return ret;
     }
 
-    return generate[parser.config.preprocessor](parser, exportName);
-};
+    var generate = function(parser, exportName) {
+        if (!parser.config.preprocessor) {
+            parser.config.preprocessor = "_default";
+        }
 
-generate.js = generate._default = generate.javascript = function (parser, exportName) {
-    var output = "// Generated automatically by nearley, version " + parser.version + "\n";
-    output +=  "// http://github.com/Hardmath123/nearley\n";
-    output += "(function () {\n";
-    output += "function id(x) { return x[0]; }\n";
-    output += parser.body.join('\n');
-    output += "var grammar = {\n";
-    output += "    Lexer: " + parser.config.lexer + ",\n";
-    output += "    ParserRules: " +
-        serializeRules(parser.rules, generate.javascript.builtinPostprocessors)
-        + "\n";
-    output += "  , ParserStart: " + JSON.stringify(parser.start) + "\n";
-    output += "}\n";
-    output += "if (typeof module !== 'undefined'"
-        + "&& typeof module.exports !== 'undefined') {\n";
-    output += "   module.exports = grammar;\n";
-    output += "} else {\n";
-    output += "   window." + exportName + " = grammar;\n";
-    output += "}\n";
-    output += "})();\n";
-    return output;
-};
-generate.javascript.builtinPostprocessors = {
-    "joiner": "function joiner(d) {return d.join('');}",
-    "arrconcat": "function arrconcat(d) {return [d[0]].concat(d[1]);}",
-    "arrpush": "function arrpush(d) {return d[0].concat([d[1]]);}",
-    "nuller": "function(d) {return null;}",
-    "id": "id"
-}
+        if (!generate[parser.config.preprocessor]) {
+            throw new Error(
+                "No such preprocessor: " + parser.config.preprocessor
+            );
+        }
 
-generate.cs = generate.coffee = generate.coffeescript = function (parser, exportName) {
-    var output = "# Generated automatically by nearley, version " + parser.version + "\n";
-    output +=  "# http://github.com/Hardmath123/nearley\n";
-    output += "do ->\n";
-    output += "  id = (d) -> d[0]\n";
-    output += tabulateString(dedentFunc(parser.body.join('\n')), '  ') + '\n';
-    output += "  grammar = {\n";
-    output += "    Lexer: " + parser.config.lexer + ",\n";
-    output += "    ParserRules: " +
-        tabulateString(
-                serializeRules(parser.rules, generate.coffeescript.builtinPostprocessors),
-                '      ',
-                {indentFirst: false})
-    + ",\n";
-    output += "    ParserStart: " + JSON.stringify(parser.start) + "\n";
-    output += "  }\n";
-    output += "  if typeof module != 'undefined' "
-        + "&& typeof module.exports != 'undefined'\n";
-    output += "    module.exports = grammar;\n";
-    output += "  else\n";
-    output += "    window." + exportName + " = grammar;\n";
-    return output;
-};
-generate.coffeescript.builtinPostprocessors = {
-    "joiner": "(d) -> d.join('')",
-    "arrconcat": "(d) -> [d[0]].concat(d[1])",
-    "arrpush": "(d) -> d[0].concat([d[1]])",
-    "nuller": "() -> null",
-    "id": "id"
-};
+        return generate[parser.config.preprocessor](parser, exportName);
+    };
 
-generate.ts = generate.typescript = function (parser, exportName) {
-    var output = "// Generated automatically by nearley, version " + parser.version + "\n";
-    output +=  "// http://github.com/Hardmath123/nearley\n";
-    output += "function id(d: any[]): any { return d[0]; }\n";
-    output += parser.customTokens.map(function (token) { return "declare var " + token + ": any;\n" }).join("")
-    output += parser.body.join('\n');
-    output += "\n";
-    output += "export interface Token { value: any; [key: string]: any };\n";
-    output += "\n";
-    output += "export interface Lexer {\n";
-    output += "  reset: (chunk: string, info: any) => void;\n";
-    output += "  next: () => Token | undefined;\n";
-    output += "  save: () => any;\n";
-    output += "  formatError: (token: Token) => string;\n";
-    output += "  has: (tokenType: string) => boolean\n";
-    output += "};\n"
-    output += "\n";
-    output += "export interface NearleyRule {\n";
-    output += "  name: string;\n";
-    output += "  symbols: NearleySymbol[];\n";
-    output += "  postprocess?: (d: any[], loc?: number, reject?: {}) => any\n";
-    output += "};\n";
-    output += "\n";
-    output += "export type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };\n";
-    output += "\n";
-    output += "export var Lexer: Lexer | undefined = " + parser.config.lexer + ";\n";
-    output += "\n";
-    output += "export var ParserRules: NearleyRule[] = " + serializeRules(parser.rules, generate.typescript.builtinPostprocessors) + ";\n";
-    output += "\n";
-    output += "export var ParserStart: string = " + JSON.stringify(parser.start) + ";\n";
-    return output;
-};
-generate.typescript.builtinPostprocessors = {
-    "joiner": "(d) => d.join('')",
-    "arrconcat": "(d) => [d[0]].concat(d[1])",
-    "arrpush": "(d) => d[0].concat([d[1]])",
-    "nuller": "() => null",
-    "id": "id"
-};
+    generate.js = generate._default = generate.javascript = function(
+        parser,
+        exportName
+    ) {
+        var output =
+            "// Generated automatically by nearley, version " +
+            parser.version +
+            "\n";
+        output += "// http://github.com/Hardmath123/nearley\n";
+        output += "(function () {\n";
+        output += "function id(x) { return x[0]; }\n";
+        output += parser.body.join("\n");
+        output += "var grammar = {\n";
+        output += "    Lexer: " + parser.config.lexer + ",\n";
+        output +=
+            "    ParserRules: " +
+            serializeRules(
+                parser.rules,
+                generate.javascript.builtinPostprocessors
+            ) +
+            "\n";
+        output += "  , ParserStart: " + JSON.stringify(parser.start) + "\n";
+        output += "}\n";
+        output +=
+            "if (typeof module !== 'undefined'" +
+            "&& typeof module.exports !== 'undefined') {\n";
+        output += "   module.exports = grammar;\n";
+        output += "} else {\n";
+        output += "   window." + exportName + " = grammar;\n";
+        output += "}\n";
+        output += "})();\n";
+        return output;
+    };
+    generate.javascript.builtinPostprocessors = {
+        joiner: "function joiner(d) {return d.join('');}",
+        arrconcat: "function arrconcat(d) {return [d[0]].concat(d[1]);}",
+        arrpush: "function arrpush(d) {return d[0].concat([d[1]]);}",
+        nuller: "function(d) {return null;}",
+        id: "id"
+    };
 
+    generate.cs = generate.coffee = generate.coffeescript = function(
+        parser,
+        exportName
+    ) {
+        var output =
+            "# Generated automatically by nearley, version " +
+            parser.version +
+            "\n";
+        output += "# http://github.com/Hardmath123/nearley\n";
+        output += "do ->\n";
+        output += "  id = (d) -> d[0]\n";
+        output +=
+            tabulateString(dedentFunc(parser.body.join("\n")), "  ") + "\n";
+        output += "  grammar = {\n";
+        output += "    Lexer: " + parser.config.lexer + ",\n";
+        output +=
+            "    ParserRules: " +
+            tabulateString(
+                serializeRules(
+                    parser.rules,
+                    generate.coffeescript.builtinPostprocessors
+                ),
+                "      ",
+                { indentFirst: false }
+            ) +
+            ",\n";
+        output += "    ParserStart: " + JSON.stringify(parser.start) + "\n";
+        output += "  }\n";
+        output +=
+            "  if typeof module != 'undefined' " +
+            "&& typeof module.exports != 'undefined'\n";
+        output += "    module.exports = grammar;\n";
+        output += "  else\n";
+        output += "    window." + exportName + " = grammar;\n";
+        return output;
+    };
+    generate.coffeescript.builtinPostprocessors = {
+        joiner: "(d) -> d.join('')",
+        arrconcat: "(d) -> [d[0]].concat(d[1])",
+        arrpush: "(d) -> d[0].concat([d[1]])",
+        nuller: "() -> null",
+        id: "id"
+    };
 
-return generate;
+    generate.ts = generate.typescript = function(parser, exportName) {
+        var output =
+            "// Generated automatically by nearley, version " +
+            parser.version +
+            "\n";
+        output += "// http://github.com/Hardmath123/nearley\n";
+        output += "function id(d: any[]): any { return d[0]; }\n";
+        output += parser.customTokens
+            .map(function(token) {
+                return "declare var " + token + ": any;\n";
+            })
+            .join("");
+        output += parser.body.join("\n");
+        output += "\n";
+        output +=
+            "export interface Token { value: any; [key: string]: any };\n";
+        output += "\n";
+        output += "export interface Lexer {\n";
+        output += "  reset: (chunk: string, info: any) => void;\n";
+        output += "  next: () => Token | undefined;\n";
+        output += "  save: () => any;\n";
+        output += "  formatError: (token: Token) => string;\n";
+        output += "  has: (tokenType: string) => boolean\n";
+        output += "};\n";
+        output += "\n";
+        output += "export interface NearleyRule {\n";
+        output += "  name: string;\n";
+        output += "  symbols: NearleySymbol[];\n";
+        output +=
+            "  postprocess?: (d: any[], loc?: number, reject?: {}) => any\n";
+        output += "};\n";
+        output += "\n";
+        output +=
+            "export type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };\n";
+        output += "\n";
+        output +=
+            "export var Lexer: Lexer | undefined = " +
+            parser.config.lexer +
+            ";\n";
+        output += "\n";
+        output +=
+            "export var ParserRules: NearleyRule[] = " +
+            serializeRules(
+                parser.rules,
+                generate.typescript.builtinPostprocessors
+            ) +
+            ";\n";
+        output += "\n";
+        output +=
+            "export var ParserStart: string = " +
+            JSON.stringify(parser.start) +
+            ";\n";
+        return output;
+    };
+    generate.typescript.builtinPostprocessors = {
+        joiner: "(d) => d.join('')",
+        arrconcat: "(d) => [d[0]].concat(d[1])",
+        arrpush: "(d) => d[0].concat([d[1]])",
+        nuller: "() => null",
+        id: "id"
+    };
 
-}));
+    return generate;
+});

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -1,9 +1,9 @@
 // Node-only
-var semver = require('semver');
+var semver = require("semver");
 
-var warn = function (opts, str) {
-    opts.out.write("WARN"+"\t" + str + "\n");
-}
+var warn = function(opts, str) {
+    opts.out.write("WARN" + "\t" + str + "\n");
+};
 
 function lintNames(grm, opts) {
     var all = [];
@@ -12,9 +12,13 @@ function lintNames(grm, opts) {
     });
     grm.rules.forEach(function(rule) {
         rule.symbols.forEach(function(symbol) {
-            if (!symbol.literal && !symbol.token && symbol.constructor !== RegExp) {
+            if (
+                !symbol.literal &&
+                !symbol.token &&
+                symbol.constructor !== RegExp
+            ) {
                 if (all.indexOf(symbol) === -1) {
-                    warn(opts,"Undefined symbol `" + symbol + "` used.");
+                    warn(opts, "Undefined symbol `" + symbol + "` used.");
                 }
             }
         });
@@ -22,12 +26,17 @@ function lintNames(grm, opts) {
 }
 
 function lintTSVersion(grm, opts) {
-    if (grm.config.preprocessor === 'typescript' &&
-        semver.gt(opts.version, '2.11.0'))
-        warn(opts, "The interface for the TypeScript preprocessor changed " +
-                   "briefly in nearley 2.10 and 2.11. See " +
-                   "https://github.com/Hardmath123/nearley/pull/287 if you " +
-                   "encounter issues importing your grammar into TS.");
+    if (
+        grm.config.preprocessor === "typescript" &&
+        semver.gt(opts.version, "2.11.0")
+    )
+        warn(
+            opts,
+            "The interface for the TypeScript preprocessor changed " +
+                "briefly in nearley 2.10 and 2.11. See " +
+                "https://github.com/Hardmath123/nearley/pull/287 if you " +
+                "encounter issues importing your grammar into TS."
+        );
 }
 
 function lint(grm, opts) {

--- a/lib/nearley-language-bootstrapped.js
+++ b/lib/nearley-language-bootstrapped.js
@@ -1,130 +1,588 @@
 // Generated automatically by nearley
 // http://github.com/Hardmath123/nearley
-(function () {
-function id(x) {return x[0]; }
-
-
-function insensitive(sl) {
-    var s = sl.literal;
-    var result = [];
-    for (var i=0; i<s.length; i++) {
-        var c = s.charAt(i);
-        if (c.toUpperCase() !== c || c.toLowerCase() !== c) {
-            result.push(new RegExp("[" + c.toLowerCase() + c.toUpperCase() + "]"));
-        } else {
-            result.push({literal: c});
-        }
+(function() {
+    function id(x) {
+        return x[0];
     }
-    return {subexpression: [{tokens: result, postprocess: function(d) {return d.join(""); }}]};
-}
 
-var grammar = {
-    Lexer: undefined,
-    ParserRules: [
-    {"name": "dqstring$ebnf$1", "symbols": []},
-    {"name": "dqstring$ebnf$1", "symbols": ["dqstring$ebnf$1", "dstrchar"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
-    {"name": "dqstring", "symbols": [{"literal":"\""}, "dqstring$ebnf$1", {"literal":"\""}], "postprocess": function(d) {return d[1].join(""); }},
-    {"name": "sqstring$ebnf$1", "symbols": []},
-    {"name": "sqstring$ebnf$1", "symbols": ["sqstring$ebnf$1", "sstrchar"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
-    {"name": "sqstring", "symbols": [{"literal":"'"}, "sqstring$ebnf$1", {"literal":"'"}], "postprocess": function(d) {return d[1].join(""); }},
-    {"name": "btstring$ebnf$1", "symbols": []},
-    {"name": "btstring$ebnf$1", "symbols": ["btstring$ebnf$1", /[^`]/], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
-    {"name": "btstring", "symbols": [{"literal":"`"}, "btstring$ebnf$1", {"literal":"`"}], "postprocess": function(d) {return d[1].join(""); }},
-    {"name": "dstrchar", "symbols": [/[^\\"\n]/], "postprocess": id},
-    {"name": "dstrchar", "symbols": [{"literal":"\\"}, "strescape"], "postprocess": 
-        function(d) {
-            return JSON.parse("\""+d.join("")+"\"");
+    function insensitive(sl) {
+        var s = sl.literal;
+        var result = [];
+        for (var i = 0; i < s.length; i++) {
+            var c = s.charAt(i);
+            if (c.toUpperCase() !== c || c.toLowerCase() !== c) {
+                result.push(
+                    new RegExp("[" + c.toLowerCase() + c.toUpperCase() + "]")
+                );
+            } else {
+                result.push({ literal: c });
+            }
         }
-        },
-    {"name": "sstrchar", "symbols": [/[^\\'\n]/], "postprocess": id},
-    {"name": "sstrchar", "symbols": [{"literal":"\\"}, "strescape"], "postprocess": function(d) { return JSON.parse("\""+d.join("")+"\""); }},
-    {"name": "sstrchar$string$1", "symbols": [{"literal":"\\"}, {"literal":"'"}], "postprocess": function joiner(d) {return d.join('');}},
-    {"name": "sstrchar", "symbols": ["sstrchar$string$1"], "postprocess": function(d) {return "'"; }},
-    {"name": "strescape", "symbols": [/["\\\/bfnrt]/], "postprocess": id},
-    {"name": "strescape", "symbols": [{"literal":"u"}, /[a-fA-F0-9]/, /[a-fA-F0-9]/, /[a-fA-F0-9]/, /[a-fA-F0-9]/], "postprocess": 
-        function(d) {
-            return d.join("");
-        }
-        },
-    {"name": "final", "symbols": ["whit?", "prog", "whit?"], "postprocess": function(d) { return d[1]; }},
-    {"name": "prog", "symbols": ["prod"], "postprocess": function(d) { return [d[0]]; }},
-    {"name": "prog", "symbols": ["prod", "whit", "prog"], "postprocess": function(d) { return [d[0]].concat(d[2]); }},
-    {"name": "prod$ebnf$1$subexpression$1", "symbols": [{"literal":"-"}]},
-    {"name": "prod$ebnf$1$subexpression$1", "symbols": [{"literal":"="}]},
-    {"name": "prod$ebnf$1", "symbols": ["prod$ebnf$1$subexpression$1"]},
-    {"name": "prod$ebnf$1$subexpression$2", "symbols": [{"literal":"-"}]},
-    {"name": "prod$ebnf$1$subexpression$2", "symbols": [{"literal":"="}]},
-    {"name": "prod$ebnf$1", "symbols": ["prod$ebnf$1", "prod$ebnf$1$subexpression$2"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
-    {"name": "prod", "symbols": ["word", "whit?", "prod$ebnf$1", {"literal":">"}, "whit?", "expression+"], "postprocess": function(d) { return {name: d[0], rules: d[5]}; }},
-    {"name": "prod$ebnf$2$subexpression$1", "symbols": [{"literal":"-"}]},
-    {"name": "prod$ebnf$2$subexpression$1", "symbols": [{"literal":"="}]},
-    {"name": "prod$ebnf$2", "symbols": ["prod$ebnf$2$subexpression$1"]},
-    {"name": "prod$ebnf$2$subexpression$2", "symbols": [{"literal":"-"}]},
-    {"name": "prod$ebnf$2$subexpression$2", "symbols": [{"literal":"="}]},
-    {"name": "prod$ebnf$2", "symbols": ["prod$ebnf$2", "prod$ebnf$2$subexpression$2"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
-    {"name": "prod", "symbols": ["word", {"literal":"["}, "wordlist", {"literal":"]"}, "whit?", "prod$ebnf$2", {"literal":">"}, "whit?", "expression+"], "postprocess": function(d) {return {macro: d[0], args: d[2], exprs: d[8]}}},
-    {"name": "prod", "symbols": [{"literal":"@"}, "whit?", "js"], "postprocess": function(d) { return {body: d[2]}; }},
-    {"name": "prod", "symbols": [{"literal":"@"}, "word", "whit", "word"], "postprocess": function(d) { return {config: d[1], value: d[3]}; }},
-    {"name": "prod$string$1", "symbols": [{"literal":"@"}, {"literal":"i"}, {"literal":"n"}, {"literal":"c"}, {"literal":"l"}, {"literal":"u"}, {"literal":"d"}, {"literal":"e"}], "postprocess": function joiner(d) {return d.join('');}},
-    {"name": "prod", "symbols": ["prod$string$1", "whit?", "string"], "postprocess": function(d) {return {include: d[2].literal, builtin: false}}},
-    {"name": "prod$string$2", "symbols": [{"literal":"@"}, {"literal":"b"}, {"literal":"u"}, {"literal":"i"}, {"literal":"l"}, {"literal":"t"}, {"literal":"i"}, {"literal":"n"}], "postprocess": function joiner(d) {return d.join('');}},
-    {"name": "prod", "symbols": ["prod$string$2", "whit?", "string"], "postprocess": function(d) {return {include: d[2].literal, builtin: true }}},
-    {"name": "expression+", "symbols": ["completeexpression"]},
-    {"name": "expression+", "symbols": ["expression+", "whit?", {"literal":"|"}, "whit?", "completeexpression"], "postprocess": function(d) { return d[0].concat([d[4]]); }},
-    {"name": "expressionlist", "symbols": ["completeexpression"]},
-    {"name": "expressionlist", "symbols": ["expressionlist", "whit?", {"literal":","}, "whit?", "completeexpression"], "postprocess": function(d) { return d[0].concat([d[4]]); }},
-    {"name": "wordlist", "symbols": ["word"]},
-    {"name": "wordlist", "symbols": ["wordlist", "whit?", {"literal":","}, "whit?", "word"], "postprocess": function(d) { return d[0].concat([d[4]]); }},
-    {"name": "completeexpression", "symbols": ["expr"], "postprocess": function(d) { return {tokens: d[0]}; }},
-    {"name": "completeexpression", "symbols": ["expr", "whit?", "js"], "postprocess": function(d) { return {tokens: d[0], postprocess: d[2]}; }},
-    {"name": "expr_member", "symbols": ["word"], "postprocess": id},
-    {"name": "expr_member", "symbols": [{"literal":"$"}, "word"], "postprocess": function(d) {return {mixin: d[1]}}},
-    {"name": "expr_member", "symbols": ["word", {"literal":"["}, "expressionlist", {"literal":"]"}], "postprocess": function(d) {return {macrocall: d[0], args: d[2]}}},
-    {"name": "expr_member$ebnf$1", "symbols": [{"literal":"i"}], "postprocess": id},
-    {"name": "expr_member$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "expr_member", "symbols": ["string", "expr_member$ebnf$1"], "postprocess": function(d) { if (d[1]) {return insensitive(d[0]); } else {return d[0]; } }},
-    {"name": "expr_member", "symbols": [{"literal":"%"}, "word"], "postprocess": function(d) {return {token: d[1]}}},
-    {"name": "expr_member", "symbols": ["charclass"], "postprocess": id},
-    {"name": "expr_member", "symbols": [{"literal":"("}, "whit?", "expression+", "whit?", {"literal":")"}], "postprocess": function(d) {return {'subexpression': d[2]} ;}},
-    {"name": "expr_member", "symbols": ["expr_member", "whit?", "ebnf_modifier"], "postprocess": function(d) {return {'ebnf': d[0], 'modifier': d[2]}; }},
-    {"name": "ebnf_modifier$string$1", "symbols": [{"literal":":"}, {"literal":"+"}], "postprocess": function joiner(d) {return d.join('');}},
-    {"name": "ebnf_modifier", "symbols": ["ebnf_modifier$string$1"], "postprocess": id},
-    {"name": "ebnf_modifier$string$2", "symbols": [{"literal":":"}, {"literal":"*"}], "postprocess": function joiner(d) {return d.join('');}},
-    {"name": "ebnf_modifier", "symbols": ["ebnf_modifier$string$2"], "postprocess": id},
-    {"name": "ebnf_modifier$string$3", "symbols": [{"literal":":"}, {"literal":"?"}], "postprocess": function joiner(d) {return d.join('');}},
-    {"name": "ebnf_modifier", "symbols": ["ebnf_modifier$string$3"], "postprocess": id},
-    {"name": "expr", "symbols": ["expr_member"]},
-    {"name": "expr", "symbols": ["expr", "whit", "expr_member"], "postprocess": function(d){ return d[0].concat([d[2]]); }},
-    {"name": "word", "symbols": [/[\w\?\+]/], "postprocess": function(d){ return d[0]; }},
-    {"name": "word", "symbols": ["word", /[\w\?\+]/], "postprocess": function(d){ return d[0]+d[1]; }},
-    {"name": "string", "symbols": ["dqstring"], "postprocess": function(d) {return { literal: d[0] }; }},
-    {"name": "charclass", "symbols": [{"literal":"."}], "postprocess": function(d) { return new RegExp("."); }},
-    {"name": "charclass", "symbols": [{"literal":"["}, "charclassmembers", {"literal":"]"}], "postprocess": function(d) { return new RegExp("[" + d[1].join('') + "]"); }},
-    {"name": "charclassmembers", "symbols": []},
-    {"name": "charclassmembers", "symbols": ["charclassmembers", "charclassmember"], "postprocess": function(d) { return d[0].concat([d[1]]); }},
-    {"name": "charclassmember", "symbols": [/[^\\\]]/], "postprocess": function(d) { return d[0]; }},
-    {"name": "charclassmember", "symbols": [{"literal":"\\"}, /./], "postprocess": function(d) { return d[0] + d[1]; }},
-    {"name": "js", "symbols": [{"literal":"{"}, {"literal":"%"}, "jscode", {"literal":"%"}, {"literal":"}"}], "postprocess": function(d) { return d[2]; }},
-    {"name": "jscode", "symbols": [], "postprocess": function() {return "";}},
-    {"name": "jscode", "symbols": ["jscode", /[^%]/], "postprocess": function(d) {return d[0] + d[1];}},
-    {"name": "jscode", "symbols": ["jscode", {"literal":"%"}, /[^}]/], "postprocess": function(d) {return d[0] + d[1] + d[2]; }},
-    {"name": "whit", "symbols": ["whitraw"]},
-    {"name": "whit", "symbols": ["whitraw?", "comment", "whit?"]},
-    {"name": "whit?", "symbols": []},
-    {"name": "whit?", "symbols": ["whit"]},
-    {"name": "whitraw", "symbols": [/[\s]/]},
-    {"name": "whitraw", "symbols": ["whitraw", /[\s]/]},
-    {"name": "whitraw?", "symbols": []},
-    {"name": "whitraw?", "symbols": ["whitraw"]},
-    {"name": "comment", "symbols": [{"literal":"#"}, "commentchars", {"literal":"\n"}]},
-    {"name": "commentchars", "symbols": []},
-    {"name": "commentchars", "symbols": ["commentchars", /[^\n]/]}
-]
-  , ParserStart: "final"
-}
-if (typeof module !== 'undefined'&& typeof module.exports !== 'undefined') {
-   module.exports = grammar;
-} else {
-   window.grammar = grammar;
-}
+        return {
+            subexpression: [
+                {
+                    tokens: result,
+                    postprocess: function(d) {
+                        return d.join("");
+                    }
+                }
+            ]
+        };
+    }
+
+    var grammar = {
+        Lexer: undefined,
+        ParserRules: [
+            { name: "dqstring$ebnf$1", symbols: [] },
+            {
+                name: "dqstring$ebnf$1",
+                symbols: ["dqstring$ebnf$1", "dstrchar"],
+                postprocess: function arrpush(d) {
+                    return d[0].concat([d[1]]);
+                }
+            },
+            {
+                name: "dqstring",
+                symbols: [
+                    { literal: '"' },
+                    "dqstring$ebnf$1",
+                    { literal: '"' }
+                ],
+                postprocess: function(d) {
+                    return d[1].join("");
+                }
+            },
+            { name: "sqstring$ebnf$1", symbols: [] },
+            {
+                name: "sqstring$ebnf$1",
+                symbols: ["sqstring$ebnf$1", "sstrchar"],
+                postprocess: function arrpush(d) {
+                    return d[0].concat([d[1]]);
+                }
+            },
+            {
+                name: "sqstring",
+                symbols: [
+                    { literal: "'" },
+                    "sqstring$ebnf$1",
+                    { literal: "'" }
+                ],
+                postprocess: function(d) {
+                    return d[1].join("");
+                }
+            },
+            { name: "btstring$ebnf$1", symbols: [] },
+            {
+                name: "btstring$ebnf$1",
+                symbols: ["btstring$ebnf$1", /[^`]/],
+                postprocess: function arrpush(d) {
+                    return d[0].concat([d[1]]);
+                }
+            },
+            {
+                name: "btstring",
+                symbols: [
+                    { literal: "`" },
+                    "btstring$ebnf$1",
+                    { literal: "`" }
+                ],
+                postprocess: function(d) {
+                    return d[1].join("");
+                }
+            },
+            { name: "dstrchar", symbols: [/[^\\"\n]/], postprocess: id },
+            {
+                name: "dstrchar",
+                symbols: [{ literal: "\\" }, "strescape"],
+                postprocess: function(d) {
+                    return JSON.parse('"' + d.join("") + '"');
+                }
+            },
+            { name: "sstrchar", symbols: [/[^\\'\n]/], postprocess: id },
+            {
+                name: "sstrchar",
+                symbols: [{ literal: "\\" }, "strescape"],
+                postprocess: function(d) {
+                    return JSON.parse('"' + d.join("") + '"');
+                }
+            },
+            {
+                name: "sstrchar$string$1",
+                symbols: [{ literal: "\\" }, { literal: "'" }],
+                postprocess: function joiner(d) {
+                    return d.join("");
+                }
+            },
+            {
+                name: "sstrchar",
+                symbols: ["sstrchar$string$1"],
+                postprocess: function(d) {
+                    return "'";
+                }
+            },
+            { name: "strescape", symbols: [/["\\\/bfnrt]/], postprocess: id },
+            {
+                name: "strescape",
+                symbols: [
+                    { literal: "u" },
+                    /[a-fA-F0-9]/,
+                    /[a-fA-F0-9]/,
+                    /[a-fA-F0-9]/,
+                    /[a-fA-F0-9]/
+                ],
+                postprocess: function(d) {
+                    return d.join("");
+                }
+            },
+            {
+                name: "final",
+                symbols: ["whit?", "prog", "whit?"],
+                postprocess: function(d) {
+                    return d[1];
+                }
+            },
+            {
+                name: "prog",
+                symbols: ["prod"],
+                postprocess: function(d) {
+                    return [d[0]];
+                }
+            },
+            {
+                name: "prog",
+                symbols: ["prod", "whit", "prog"],
+                postprocess: function(d) {
+                    return [d[0]].concat(d[2]);
+                }
+            },
+            {
+                name: "prod$ebnf$1$subexpression$1",
+                symbols: [{ literal: "-" }]
+            },
+            {
+                name: "prod$ebnf$1$subexpression$1",
+                symbols: [{ literal: "=" }]
+            },
+            { name: "prod$ebnf$1", symbols: ["prod$ebnf$1$subexpression$1"] },
+            {
+                name: "prod$ebnf$1$subexpression$2",
+                symbols: [{ literal: "-" }]
+            },
+            {
+                name: "prod$ebnf$1$subexpression$2",
+                symbols: [{ literal: "=" }]
+            },
+            {
+                name: "prod$ebnf$1",
+                symbols: ["prod$ebnf$1", "prod$ebnf$1$subexpression$2"],
+                postprocess: function arrpush(d) {
+                    return d[0].concat([d[1]]);
+                }
+            },
+            {
+                name: "prod",
+                symbols: [
+                    "word",
+                    "whit?",
+                    "prod$ebnf$1",
+                    { literal: ">" },
+                    "whit?",
+                    "expression+"
+                ],
+                postprocess: function(d) {
+                    return { name: d[0], rules: d[5] };
+                }
+            },
+            {
+                name: "prod$ebnf$2$subexpression$1",
+                symbols: [{ literal: "-" }]
+            },
+            {
+                name: "prod$ebnf$2$subexpression$1",
+                symbols: [{ literal: "=" }]
+            },
+            { name: "prod$ebnf$2", symbols: ["prod$ebnf$2$subexpression$1"] },
+            {
+                name: "prod$ebnf$2$subexpression$2",
+                symbols: [{ literal: "-" }]
+            },
+            {
+                name: "prod$ebnf$2$subexpression$2",
+                symbols: [{ literal: "=" }]
+            },
+            {
+                name: "prod$ebnf$2",
+                symbols: ["prod$ebnf$2", "prod$ebnf$2$subexpression$2"],
+                postprocess: function arrpush(d) {
+                    return d[0].concat([d[1]]);
+                }
+            },
+            {
+                name: "prod",
+                symbols: [
+                    "word",
+                    { literal: "[" },
+                    "wordlist",
+                    { literal: "]" },
+                    "whit?",
+                    "prod$ebnf$2",
+                    { literal: ">" },
+                    "whit?",
+                    "expression+"
+                ],
+                postprocess: function(d) {
+                    return { macro: d[0], args: d[2], exprs: d[8] };
+                }
+            },
+            {
+                name: "prod",
+                symbols: [{ literal: "@" }, "whit?", "js"],
+                postprocess: function(d) {
+                    return { body: d[2] };
+                }
+            },
+            {
+                name: "prod",
+                symbols: [{ literal: "@" }, "word", "whit", "word"],
+                postprocess: function(d) {
+                    return { config: d[1], value: d[3] };
+                }
+            },
+            {
+                name: "prod$string$1",
+                symbols: [
+                    { literal: "@" },
+                    { literal: "i" },
+                    { literal: "n" },
+                    { literal: "c" },
+                    { literal: "l" },
+                    { literal: "u" },
+                    { literal: "d" },
+                    { literal: "e" }
+                ],
+                postprocess: function joiner(d) {
+                    return d.join("");
+                }
+            },
+            {
+                name: "prod",
+                symbols: ["prod$string$1", "whit?", "string"],
+                postprocess: function(d) {
+                    return { include: d[2].literal, builtin: false };
+                }
+            },
+            {
+                name: "prod$string$2",
+                symbols: [
+                    { literal: "@" },
+                    { literal: "b" },
+                    { literal: "u" },
+                    { literal: "i" },
+                    { literal: "l" },
+                    { literal: "t" },
+                    { literal: "i" },
+                    { literal: "n" }
+                ],
+                postprocess: function joiner(d) {
+                    return d.join("");
+                }
+            },
+            {
+                name: "prod",
+                symbols: ["prod$string$2", "whit?", "string"],
+                postprocess: function(d) {
+                    return { include: d[2].literal, builtin: true };
+                }
+            },
+            { name: "expression+", symbols: ["completeexpression"] },
+            {
+                name: "expression+",
+                symbols: [
+                    "expression+",
+                    "whit?",
+                    { literal: "|" },
+                    "whit?",
+                    "completeexpression"
+                ],
+                postprocess: function(d) {
+                    return d[0].concat([d[4]]);
+                }
+            },
+            { name: "expressionlist", symbols: ["completeexpression"] },
+            {
+                name: "expressionlist",
+                symbols: [
+                    "expressionlist",
+                    "whit?",
+                    { literal: "," },
+                    "whit?",
+                    "completeexpression"
+                ],
+                postprocess: function(d) {
+                    return d[0].concat([d[4]]);
+                }
+            },
+            { name: "wordlist", symbols: ["word"] },
+            {
+                name: "wordlist",
+                symbols: [
+                    "wordlist",
+                    "whit?",
+                    { literal: "," },
+                    "whit?",
+                    "word"
+                ],
+                postprocess: function(d) {
+                    return d[0].concat([d[4]]);
+                }
+            },
+            {
+                name: "completeexpression",
+                symbols: ["expr"],
+                postprocess: function(d) {
+                    return { tokens: d[0] };
+                }
+            },
+            {
+                name: "completeexpression",
+                symbols: ["expr", "whit?", "js"],
+                postprocess: function(d) {
+                    return { tokens: d[0], postprocess: d[2] };
+                }
+            },
+            { name: "expr_member", symbols: ["word"], postprocess: id },
+            {
+                name: "expr_member",
+                symbols: [{ literal: "$" }, "word"],
+                postprocess: function(d) {
+                    return { mixin: d[1] };
+                }
+            },
+            {
+                name: "expr_member",
+                symbols: [
+                    "word",
+                    { literal: "[" },
+                    "expressionlist",
+                    { literal: "]" }
+                ],
+                postprocess: function(d) {
+                    return { macrocall: d[0], args: d[2] };
+                }
+            },
+            {
+                name: "expr_member$ebnf$1",
+                symbols: [{ literal: "i" }],
+                postprocess: id
+            },
+            {
+                name: "expr_member$ebnf$1",
+                symbols: [],
+                postprocess: function(d) {
+                    return null;
+                }
+            },
+            {
+                name: "expr_member",
+                symbols: ["string", "expr_member$ebnf$1"],
+                postprocess: function(d) {
+                    if (d[1]) {
+                        return insensitive(d[0]);
+                    } else {
+                        return d[0];
+                    }
+                }
+            },
+            {
+                name: "expr_member",
+                symbols: [{ literal: "%" }, "word"],
+                postprocess: function(d) {
+                    return { token: d[1] };
+                }
+            },
+            { name: "expr_member", symbols: ["charclass"], postprocess: id },
+            {
+                name: "expr_member",
+                symbols: [
+                    { literal: "(" },
+                    "whit?",
+                    "expression+",
+                    "whit?",
+                    { literal: ")" }
+                ],
+                postprocess: function(d) {
+                    return { subexpression: d[2] };
+                }
+            },
+            {
+                name: "expr_member",
+                symbols: ["expr_member", "whit?", "ebnf_modifier"],
+                postprocess: function(d) {
+                    return { ebnf: d[0], modifier: d[2] };
+                }
+            },
+            {
+                name: "ebnf_modifier$string$1",
+                symbols: [{ literal: ":" }, { literal: "+" }],
+                postprocess: function joiner(d) {
+                    return d.join("");
+                }
+            },
+            {
+                name: "ebnf_modifier",
+                symbols: ["ebnf_modifier$string$1"],
+                postprocess: id
+            },
+            {
+                name: "ebnf_modifier$string$2",
+                symbols: [{ literal: ":" }, { literal: "*" }],
+                postprocess: function joiner(d) {
+                    return d.join("");
+                }
+            },
+            {
+                name: "ebnf_modifier",
+                symbols: ["ebnf_modifier$string$2"],
+                postprocess: id
+            },
+            {
+                name: "ebnf_modifier$string$3",
+                symbols: [{ literal: ":" }, { literal: "?" }],
+                postprocess: function joiner(d) {
+                    return d.join("");
+                }
+            },
+            {
+                name: "ebnf_modifier",
+                symbols: ["ebnf_modifier$string$3"],
+                postprocess: id
+            },
+            { name: "expr", symbols: ["expr_member"] },
+            {
+                name: "expr",
+                symbols: ["expr", "whit", "expr_member"],
+                postprocess: function(d) {
+                    return d[0].concat([d[2]]);
+                }
+            },
+            {
+                name: "word",
+                symbols: [/[\w\?\+]/],
+                postprocess: function(d) {
+                    return d[0];
+                }
+            },
+            {
+                name: "word",
+                symbols: ["word", /[\w\?\+]/],
+                postprocess: function(d) {
+                    return d[0] + d[1];
+                }
+            },
+            {
+                name: "string",
+                symbols: ["dqstring"],
+                postprocess: function(d) {
+                    return { literal: d[0] };
+                }
+            },
+            {
+                name: "charclass",
+                symbols: [{ literal: "." }],
+                postprocess: function(d) {
+                    return new RegExp(".");
+                }
+            },
+            {
+                name: "charclass",
+                symbols: [
+                    { literal: "[" },
+                    "charclassmembers",
+                    { literal: "]" }
+                ],
+                postprocess: function(d) {
+                    return new RegExp("[" + d[1].join("") + "]");
+                }
+            },
+            { name: "charclassmembers", symbols: [] },
+            {
+                name: "charclassmembers",
+                symbols: ["charclassmembers", "charclassmember"],
+                postprocess: function(d) {
+                    return d[0].concat([d[1]]);
+                }
+            },
+            {
+                name: "charclassmember",
+                symbols: [/[^\\\]]/],
+                postprocess: function(d) {
+                    return d[0];
+                }
+            },
+            {
+                name: "charclassmember",
+                symbols: [{ literal: "\\" }, /./],
+                postprocess: function(d) {
+                    return d[0] + d[1];
+                }
+            },
+            {
+                name: "js",
+                symbols: [
+                    { literal: "{" },
+                    { literal: "%" },
+                    "jscode",
+                    { literal: "%" },
+                    { literal: "}" }
+                ],
+                postprocess: function(d) {
+                    return d[2];
+                }
+            },
+            {
+                name: "jscode",
+                symbols: [],
+                postprocess: function() {
+                    return "";
+                }
+            },
+            {
+                name: "jscode",
+                symbols: ["jscode", /[^%]/],
+                postprocess: function(d) {
+                    return d[0] + d[1];
+                }
+            },
+            {
+                name: "jscode",
+                symbols: ["jscode", { literal: "%" }, /[^}]/],
+                postprocess: function(d) {
+                    return d[0] + d[1] + d[2];
+                }
+            },
+            { name: "whit", symbols: ["whitraw"] },
+            { name: "whit", symbols: ["whitraw?", "comment", "whit?"] },
+            { name: "whit?", symbols: [] },
+            { name: "whit?", symbols: ["whit"] },
+            { name: "whitraw", symbols: [/[\s]/] },
+            { name: "whitraw", symbols: ["whitraw", /[\s]/] },
+            { name: "whitraw?", symbols: [] },
+            { name: "whitraw?", symbols: ["whitraw"] },
+            {
+                name: "comment",
+                symbols: [{ literal: "#" }, "commentchars", { literal: "\n" }]
+            },
+            { name: "commentchars", symbols: [] },
+            { name: "commentchars", symbols: ["commentchars", /[^\n]/] }
+        ],
+        ParserStart: "final"
+    };
+    if (
+        typeof module !== "undefined" &&
+        typeof module.exports !== "undefined"
+    ) {
+        module.exports = grammar;
+    } else {
+        window.grammar = grammar;
+    }
 })();

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -1,390 +1,427 @@
 (function(root, factory) {
-    if (typeof module === 'object' && module.exports) {
+    if (typeof module === "object" && module.exports) {
         module.exports = factory();
     } else {
         root.nearley = factory();
     }
-}(this, function() {
-
-function Rule(name, symbols, postprocess) {
-    this.id = ++Rule.highestId;
-    this.name = name;
-    this.symbols = symbols;        // a list of literal | regex class | nonterminal
-    this.postprocess = postprocess;
-    return this;
-}
-Rule.highestId = 0;
-
-Rule.prototype.toString = function(withCursorAt) {
-    function stringifySymbolSequence (e) {
-        return e.literal ? JSON.stringify(e.literal) :
-               e.type ? '%' + e.type : e.toString();
+})(this, function() {
+    function Rule(name, symbols, postprocess) {
+        this.id = ++Rule.highestId;
+        this.name = name;
+        this.symbols = symbols; // a list of literal | regex class | nonterminal
+        this.postprocess = postprocess;
+        return this;
     }
-    var symbolSequence = (typeof withCursorAt === "undefined")
-                         ? this.symbols.map(stringifySymbolSequence).join(' ')
-                         : (   this.symbols.slice(0, withCursorAt).map(stringifySymbolSequence).join(' ')
-                             + " ● "
-                             + this.symbols.slice(withCursorAt).map(stringifySymbolSequence).join(' ')     );
-    return this.name + " → " + symbolSequence;
-}
+    Rule.highestId = 0;
 
+    Rule.prototype.toString = function(withCursorAt) {
+        function stringifySymbolSequence(e) {
+            return e.literal
+                ? JSON.stringify(e.literal)
+                : e.type ? "%" + e.type : e.toString();
+        }
+        var symbolSequence =
+            typeof withCursorAt === "undefined"
+                ? this.symbols.map(stringifySymbolSequence).join(" ")
+                : this.symbols
+                      .slice(0, withCursorAt)
+                      .map(stringifySymbolSequence)
+                      .join(" ") +
+                  " ● " +
+                  this.symbols
+                      .slice(withCursorAt)
+                      .map(stringifySymbolSequence)
+                      .join(" ");
+        return this.name + " → " + symbolSequence;
+    };
 
-// a State is a rule at a position from a given starting point in the input stream (reference)
-function State(rule, dot, reference, wantedBy) {
-    this.rule = rule;
-    this.dot = dot;
-    this.reference = reference;
-    this.data = [];
-    this.wantedBy = wantedBy;
-    this.isComplete = this.dot === rule.symbols.length;
-}
-
-State.prototype.toString = function() {
-    return "{" + this.rule.toString(this.dot) + "}, from: " + (this.reference || 0);
-};
-
-State.prototype.nextState = function(child) {
-    var state = new State(this.rule, this.dot + 1, this.reference, this.wantedBy);
-    state.left = this;
-    state.right = child;
-    if (state.isComplete) {
-        state.data = state.build();
+    // a State is a rule at a position from a given starting point in the input stream (reference)
+    function State(rule, dot, reference, wantedBy) {
+        this.rule = rule;
+        this.dot = dot;
+        this.reference = reference;
+        this.data = [];
+        this.wantedBy = wantedBy;
+        this.isComplete = this.dot === rule.symbols.length;
     }
-    return state;
-};
 
-State.prototype.build = function() {
-    var children = [];
-    var node = this;
-    do {
-        children.push(node.right.data);
-        node = node.left;
-    } while (node.left);
-    children.reverse();
-    return children;
-};
+    State.prototype.toString = function() {
+        return (
+            "{" +
+            this.rule.toString(this.dot) +
+            "}, from: " +
+            (this.reference || 0)
+        );
+    };
 
-State.prototype.finish = function() {
-    if (this.rule.postprocess) {
-        this.data = this.rule.postprocess(this.data, this.reference, Parser.fail);
-    }
-};
-
-
-function Column(grammar, index) {
-    this.grammar = grammar;
-    this.index = index;
-    this.states = [];
-    this.wants = {}; // states indexed by the non-terminal they expect
-    this.scannable = []; // list of states that expect a token
-    this.completed = {}; // states that are nullable
-}
-
-
-Column.prototype.process = function(nextColumn) {
-    var states = this.states;
-    var wants = this.wants;
-    var completed = this.completed;
-
-    for (var w = 0; w < states.length; w++) { // nb. we push() during iteration
-        var state = states[w];
-
+    State.prototype.nextState = function(child) {
+        var state = new State(
+            this.rule,
+            this.dot + 1,
+            this.reference,
+            this.wantedBy
+        );
+        state.left = this;
+        state.right = child;
         if (state.isComplete) {
-            state.finish();
-            if (state.data !== Parser.fail) {
-                // complete
-                var wantedBy = state.wantedBy;
-                for (var i = wantedBy.length; i--; ) { // this line is hot
-                    var left = wantedBy[i];
-                    this.complete(left, state);
-                }
+            state.data = state.build();
+        }
+        return state;
+    };
 
-                // special-case nullables
-                if (state.reference === this.index) {
-                    // make sure future predictors of this rule get completed.
-                    var exp = state.rule.name;
-                    (this.completed[exp] = this.completed[exp] || []).push(state);
-                }
-            }
+    State.prototype.build = function() {
+        var children = [];
+        var node = this;
+        do {
+            children.push(node.right.data);
+            node = node.left;
+        } while (node.left);
+        children.reverse();
+        return children;
+    };
 
-        } else {
-            // queue scannable states
-            var exp = state.rule.symbols[state.dot];
-            if (typeof exp !== 'string') {
-                this.scannable.push(state);
-                continue;
-            }
+    State.prototype.finish = function() {
+        if (this.rule.postprocess) {
+            this.data = this.rule.postprocess(
+                this.data,
+                this.reference,
+                Parser.fail
+            );
+        }
+    };
 
-            // predict
-            if (wants[exp]) {
-                wants[exp].push(state);
+    function Column(grammar, index) {
+        this.grammar = grammar;
+        this.index = index;
+        this.states = [];
+        this.wants = {}; // states indexed by the non-terminal they expect
+        this.scannable = []; // list of states that expect a token
+        this.completed = {}; // states that are nullable
+    }
 
-                if (completed.hasOwnProperty(exp)) {
-                    var nulls = completed[exp];
-                    for (var i = 0; i < nulls.length; i++) {
-                        var right = nulls[i];
-                        this.complete(state, right);
+    Column.prototype.process = function(nextColumn) {
+        var states = this.states;
+        var wants = this.wants;
+        var completed = this.completed;
+
+        for (var w = 0; w < states.length; w++) {
+            // nb. we push() during iteration
+            var state = states[w];
+
+            if (state.isComplete) {
+                state.finish();
+                if (state.data !== Parser.fail) {
+                    // complete
+                    var wantedBy = state.wantedBy;
+                    for (var i = wantedBy.length; i--; ) {
+                        // this line is hot
+                        var left = wantedBy[i];
+                        this.complete(left, state);
+                    }
+
+                    // special-case nullables
+                    if (state.reference === this.index) {
+                        // make sure future predictors of this rule get completed.
+                        var exp = state.rule.name;
+                        (this.completed[exp] = this.completed[exp] || []).push(
+                            state
+                        );
                     }
                 }
             } else {
-                wants[exp] = [state];
-                this.predict(exp);
+                // queue scannable states
+                var exp = state.rule.symbols[state.dot];
+                if (typeof exp !== "string") {
+                    this.scannable.push(state);
+                    continue;
+                }
+
+                // predict
+                if (wants[exp]) {
+                    wants[exp].push(state);
+
+                    if (completed.hasOwnProperty(exp)) {
+                        var nulls = completed[exp];
+                        for (var i = 0; i < nulls.length; i++) {
+                            var right = nulls[i];
+                            this.complete(state, right);
+                        }
+                    }
+                } else {
+                    wants[exp] = [state];
+                    this.predict(exp);
+                }
             }
         }
-    }
-}
-
-Column.prototype.predict = function(exp) {
-    var rules = this.grammar.byName[exp] || [];
-
-    for (var i = 0; i < rules.length; i++) {
-        var r = rules[i];
-        var wantedBy = this.wants[exp];
-        var s = new State(r, 0, this.index, wantedBy);
-        this.states.push(s);
-    }
-}
-
-Column.prototype.complete = function(left, right) {
-    var copy = left.nextState(right);
-    this.states.push(copy);
-}
-
-
-function Grammar(rules, start) {
-    this.rules = rules;
-    this.start = start || this.rules[0].name;
-    var byName = this.byName = {};
-    this.rules.forEach(function(rule) {
-        if (!byName.hasOwnProperty(rule.name)) {
-            byName[rule.name] = [];
-        }
-        byName[rule.name].push(rule);
-    });
-}
-
-// So we can allow passing (rules, start) directly to Parser for backwards compatibility
-Grammar.fromCompiled = function(rules, start) {
-    var lexer = rules.Lexer;
-    if (rules.ParserStart) {
-      start = rules.ParserStart;
-      rules = rules.ParserRules;
-    }
-    var rules = rules.map(function (r) { return (new Rule(r.name, r.symbols, r.postprocess)); });
-    var g = new Grammar(rules, start);
-    g.lexer = lexer; // nb. storing lexer on Grammar is iffy, but unavoidable
-    return g;
-}
-
-
-function StreamLexer() {
-  this.reset("");
-}
-
-StreamLexer.prototype.reset = function(data, state) {
-    this.buffer = data;
-    this.index = 0;
-    this.line = state ? state.line : 1;
-    this.lastLineBreak = state ? -state.col : 0;
-}
-
-StreamLexer.prototype.next = function() {
-    if (this.index < this.buffer.length) {
-        var ch = this.buffer[this.index++];
-        if (ch === '\n') {
-          this.line += 1;
-          this.lastLineBreak = this.index;
-        }
-        return {value: ch};
-    }
-}
-
-StreamLexer.prototype.save = function() {
-  return {
-    line: this.line,
-    col: this.index - this.lastLineBreak,
-  }
-}
-
-StreamLexer.prototype.formatError = function(token, message) {
-    // nb. this gets called after consuming the offending token,
-    // so the culprit is index-1
-    var buffer = this.buffer;
-    if (typeof buffer === 'string') {
-        var nextLineBreak = buffer.indexOf('\n', this.index);
-        if (nextLineBreak === -1) nextLineBreak = buffer.length;
-        var line = buffer.substring(this.lastLineBreak, nextLineBreak)
-        var col = this.index - this.lastLineBreak;
-        message += " at line " + this.line + " col " + col + ":\n\n";
-        message += "  " + line + "\n"
-        message += "  " + Array(col).join(" ") + "^"
-        return message;
-    } else {
-        return message + " at index " + (this.index - 1);
-    }
-}
-
-
-function Parser(rules, start, options) {
-    if (rules instanceof Grammar) {
-        var grammar = rules;
-        var options = start;
-    } else {
-        var grammar = Grammar.fromCompiled(rules, start);
-    }
-    this.grammar = grammar;
-
-    // Read options
-    this.options = {
-        keepHistory: false,
-        lexer: grammar.lexer || new StreamLexer,
     };
-    for (var key in (options || {})) {
-        this.options[key] = options[key];
-    }
 
-    // Setup lexer
-    this.lexer = this.options.lexer;
-    this.lexerState = undefined;
+    Column.prototype.predict = function(exp) {
+        var rules = this.grammar.byName[exp] || [];
 
-    // Setup a table
-    var column = new Column(grammar, 0);
-    var table = this.table = [column];
-
-    // I could be expecting anything.
-    column.wants[grammar.start] = [];
-    column.predict(grammar.start);
-    // TODO what if start rule is nullable?
-    column.process();
-    this.current = 0; // token index
-}
-
-// create a reserved token for indicating a parse fail
-Parser.fail = {};
-
-Parser.prototype.feed = function(chunk) {
-    var lexer = this.lexer;
-    lexer.reset(chunk, this.lexerState);
-
-    var token;
-    while (token = lexer.next()) {
-        // We add new states to table[current+1]
-        var column = this.table[this.current];
-
-        // GC unused states
-        if (!this.options.keepHistory) {
-            delete this.table[this.current - 1];
+        for (var i = 0; i < rules.length; i++) {
+            var r = rules[i];
+            var wantedBy = this.wants[exp];
+            var s = new State(r, 0, this.index, wantedBy);
+            this.states.push(s);
         }
+    };
 
-        var n = this.current + 1;
-        var nextColumn = new Column(this.grammar, n);
-        this.table.push(nextColumn);
+    Column.prototype.complete = function(left, right) {
+        var copy = left.nextState(right);
+        this.states.push(copy);
+    };
 
-        // Advance all tokens that expect the symbol
-        var literal = token.value;
-        var value = lexer.constructor === StreamLexer ? token.value : token;
-        var scannable = column.scannable;
-        for (var w = scannable.length; w--; ) {
-            var state = scannable[w];
-            var expect = state.rule.symbols[state.dot];
-            // Try to consume the token
-            // either regex or literal
-            if (expect.test ? expect.test(value) :
-                expect.type ? expect.type === token.type
-                            : expect.literal === literal) {
-                // Add it
-                var next = state.nextState({data: value, token: token, isToken: true, reference: n - 1});
-                nextColumn.states.push(next);
+    function Grammar(rules, start) {
+        this.rules = rules;
+        this.start = start || this.rules[0].name;
+        var byName = (this.byName = {});
+        this.rules.forEach(function(rule) {
+            if (!byName.hasOwnProperty(rule.name)) {
+                byName[rule.name] = [];
             }
-        }
-
-        // Next, for each of the rules, we either
-        // (a) complete it, and try to see if the reference row expected that
-        //     rule
-        // (b) predict the next nonterminal it expects by adding that
-        //     nonterminal's start state
-        // To prevent duplication, we also keep track of rules we have already
-        // added
-
-        nextColumn.process();
-
-        // If needed, throw an error:
-        if (nextColumn.states.length === 0) {
-            // No states at all! This is not good.
-            var message = this.lexer.formatError(token, "invalid syntax") + "\n";
-            message += "Unexpected " + (token.type ? token.type + " token: " : "");
-            message += JSON.stringify(token.value !== undefined ? token.value : token) + "\n";
-            var err = new Error(message);
-            err.offset = this.current;
-            err.token = token;
-            throw err;
-        }
-
-        // maybe save lexer state
-        if (this.options.keepHistory) {
-          column.lexerState = lexer.save()
-        }
-
-        this.current++;
-    }
-    if (column) {
-      this.lexerState = lexer.save()
+            byName[rule.name].push(rule);
+        });
     }
 
-    // Incrementally keep track of results
-    this.results = this.finish();
-
-    // Allow chaining, for whatever it's worth
-    return this;
-};
-
-Parser.prototype.save = function() {
-    var column = this.table[this.current];
-    column.lexerState = this.lexerState;
-    return column;
-};
-
-Parser.prototype.restore = function(column) {
-    var index = column.index;
-    this.current = index;
-    this.table[index] = column;
-    this.table.splice(index + 1);
-    this.lexerState = column.lexerState;
-
-    // Incrementally keep track of results
-    this.results = this.finish();
-};
-
-// nb. deprecated: use save/restore instead!
-Parser.prototype.rewind = function(index) {
-    if (!this.options.keepHistory) {
-        throw new Error('set option `keepHistory` to enable rewinding')
-    }
-    // nb. recall column (table) indicies fall between token indicies.
-    //        col 0   --   token 0   --   col 1
-    this.restore(this.table[index]);
-};
-
-Parser.prototype.finish = function() {
-    // Return the possible parsings
-    var considerations = [];
-    var start = this.grammar.start;
-    var column = this.table[this.table.length - 1]
-    column.states.forEach(function (t) {
-        if (t.rule.name === start
-                && t.dot === t.rule.symbols.length
-                && t.reference === 0
-                && t.data !== Parser.fail) {
-            considerations.push(t);
+    // So we can allow passing (rules, start) directly to Parser for backwards compatibility
+    Grammar.fromCompiled = function(rules, start) {
+        var lexer = rules.Lexer;
+        if (rules.ParserStart) {
+            start = rules.ParserStart;
+            rules = rules.ParserRules;
         }
-    });
-    return considerations.map(function(c) {return c.data; });
-};
+        var rules = rules.map(function(r) {
+            return new Rule(r.name, r.symbols, r.postprocess);
+        });
+        var g = new Grammar(rules, start);
+        g.lexer = lexer; // nb. storing lexer on Grammar is iffy, but unavoidable
+        return g;
+    };
 
-return {
-    Parser: Parser,
-    Grammar: Grammar,
-    Rule: Rule,
-};
+    function StreamLexer() {
+        this.reset("");
+    }
 
-}));
+    StreamLexer.prototype.reset = function(data, state) {
+        this.buffer = data;
+        this.index = 0;
+        this.line = state ? state.line : 1;
+        this.lastLineBreak = state ? -state.col : 0;
+    };
+
+    StreamLexer.prototype.next = function() {
+        if (this.index < this.buffer.length) {
+            var ch = this.buffer[this.index++];
+            if (ch === "\n") {
+                this.line += 1;
+                this.lastLineBreak = this.index;
+            }
+            return { value: ch };
+        }
+    };
+
+    StreamLexer.prototype.save = function() {
+        return {
+            line: this.line,
+            col: this.index - this.lastLineBreak
+        };
+    };
+
+    StreamLexer.prototype.formatError = function(token, message) {
+        // nb. this gets called after consuming the offending token,
+        // so the culprit is index-1
+        var buffer = this.buffer;
+        if (typeof buffer === "string") {
+            var nextLineBreak = buffer.indexOf("\n", this.index);
+            if (nextLineBreak === -1) nextLineBreak = buffer.length;
+            var line = buffer.substring(this.lastLineBreak, nextLineBreak);
+            var col = this.index - this.lastLineBreak;
+            message += " at line " + this.line + " col " + col + ":\n\n";
+            message += "  " + line + "\n";
+            message += "  " + Array(col).join(" ") + "^";
+            return message;
+        } else {
+            return message + " at index " + (this.index - 1);
+        }
+    };
+
+    function Parser(rules, start, options) {
+        if (rules instanceof Grammar) {
+            var grammar = rules;
+            var options = start;
+        } else {
+            var grammar = Grammar.fromCompiled(rules, start);
+        }
+        this.grammar = grammar;
+
+        // Read options
+        this.options = {
+            keepHistory: false,
+            lexer: grammar.lexer || new StreamLexer()
+        };
+        for (var key in options || {}) {
+            this.options[key] = options[key];
+        }
+
+        // Setup lexer
+        this.lexer = this.options.lexer;
+        this.lexerState = undefined;
+
+        // Setup a table
+        var column = new Column(grammar, 0);
+        var table = (this.table = [column]);
+
+        // I could be expecting anything.
+        column.wants[grammar.start] = [];
+        column.predict(grammar.start);
+        // TODO what if start rule is nullable?
+        column.process();
+        this.current = 0; // token index
+    }
+
+    // create a reserved token for indicating a parse fail
+    Parser.fail = {};
+
+    Parser.prototype.feed = function(chunk) {
+        var lexer = this.lexer;
+        lexer.reset(chunk, this.lexerState);
+
+        var token;
+        while ((token = lexer.next())) {
+            // We add new states to table[current+1]
+            var column = this.table[this.current];
+
+            // GC unused states
+            if (!this.options.keepHistory) {
+                delete this.table[this.current - 1];
+            }
+
+            var n = this.current + 1;
+            var nextColumn = new Column(this.grammar, n);
+            this.table.push(nextColumn);
+
+            // Advance all tokens that expect the symbol
+            var literal = token.value;
+            var value = lexer.constructor === StreamLexer ? token.value : token;
+            var scannable = column.scannable;
+            for (var w = scannable.length; w--; ) {
+                var state = scannable[w];
+                var expect = state.rule.symbols[state.dot];
+                // Try to consume the token
+                // either regex or literal
+                if (
+                    expect.test
+                        ? expect.test(value)
+                        : expect.type
+                          ? expect.type === token.type
+                          : expect.literal === literal
+                ) {
+                    // Add it
+                    var next = state.nextState({
+                        data: value,
+                        token: token,
+                        isToken: true,
+                        reference: n - 1
+                    });
+                    nextColumn.states.push(next);
+                }
+            }
+
+            // Next, for each of the rules, we either
+            // (a) complete it, and try to see if the reference row expected that
+            //     rule
+            // (b) predict the next nonterminal it expects by adding that
+            //     nonterminal's start state
+            // To prevent duplication, we also keep track of rules we have already
+            // added
+
+            nextColumn.process();
+
+            // If needed, throw an error:
+            if (nextColumn.states.length === 0) {
+                // No states at all! This is not good.
+                var message =
+                    this.lexer.formatError(token, "invalid syntax") + "\n";
+                message +=
+                    "Unexpected " + (token.type ? token.type + " token: " : "");
+                message +=
+                    JSON.stringify(
+                        token.value !== undefined ? token.value : token
+                    ) + "\n";
+                var err = new Error(message);
+                err.offset = this.current;
+                err.token = token;
+                throw err;
+            }
+
+            // maybe save lexer state
+            if (this.options.keepHistory) {
+                column.lexerState = lexer.save();
+            }
+
+            this.current++;
+        }
+        if (column) {
+            this.lexerState = lexer.save();
+        }
+
+        // Incrementally keep track of results
+        this.results = this.finish();
+
+        // Allow chaining, for whatever it's worth
+        return this;
+    };
+
+    Parser.prototype.save = function() {
+        var column = this.table[this.current];
+        column.lexerState = this.lexerState;
+        return column;
+    };
+
+    Parser.prototype.restore = function(column) {
+        var index = column.index;
+        this.current = index;
+        this.table[index] = column;
+        this.table.splice(index + 1);
+        this.lexerState = column.lexerState;
+
+        // Incrementally keep track of results
+        this.results = this.finish();
+    };
+
+    // nb. deprecated: use save/restore instead!
+    Parser.prototype.rewind = function(index) {
+        if (!this.options.keepHistory) {
+            throw new Error("set option `keepHistory` to enable rewinding");
+        }
+        // nb. recall column (table) indicies fall between token indicies.
+        //        col 0   --   token 0   --   col 1
+        this.restore(this.table[index]);
+    };
+
+    Parser.prototype.finish = function() {
+        // Return the possible parsings
+        var considerations = [];
+        var start = this.grammar.start;
+        var column = this.table[this.table.length - 1];
+        column.states.forEach(function(t) {
+            if (
+                t.rule.name === start &&
+                t.dot === t.rule.symbols.length &&
+                t.reference === 0 &&
+                t.data !== Parser.fail
+            ) {
+                considerations.push(t);
+            }
+        });
+        return considerations.map(function(c) {
+            return c.data;
+        });
+    };
+
+    return {
+        Parser: Parser,
+        Grammar: Grammar,
+        Rule: Rule
+    };
+});

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,7 +1,7 @@
 // Node-only
 
-var Writable = require('stream').Writable;
-var util = require('util');
+var Writable = require("stream").Writable;
+var util = require("util");
 
 function StreamWrapper(parser) {
     Writable.call(this);

--- a/package-lock.json
+++ b/package-lock.json
@@ -921,6 +921,12 @@
         "xtend": "4.0.1"
       }
     },
+    "prettier": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.7.4.tgz",
+      "integrity": "sha1-XoYkrpNjyA+V7GRFhOzfVddPk/o=",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,47 @@
       "integrity": "sha512-KQHAZeVsk4UIT9XaR6cn4WpHZzimK6UBD1UomQKfQQFmTlUHaNBzeuov+TM4+kigLO0IJt4I5OOsshcCyA9gSA==",
       "dev": true
     },
+    "acorn": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "json-schema-traverse": "0.3.1",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+      "dev": true
+    },
     "anchor-markdown-header": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz",
@@ -24,6 +65,12 @@
       "requires": {
         "emoji-regex": "6.1.3"
       }
+    },
+    "ansi-escapes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -53,10 +100,57 @@
         "readable-stream": "2.3.3"
       }
     },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
     "bail": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
       "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "benchmark": {
@@ -100,6 +194,31 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
       "integrity": "sha1-TWfcJgLAzBbdm85+v4fpSCkPWBI=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "ccount": {
@@ -159,12 +278,39 @@
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
       "dev": true
     },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
     "clone": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
       "dev": true,
       "optional": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -184,10 +330,42 @@
       "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw=",
       "dev": true
     },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "colors": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
       "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -200,6 +378,29 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        }
+      }
     },
     "debug": {
       "version": "2.6.8",
@@ -214,6 +415,12 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "defaults": {
@@ -234,6 +441,21 @@
       "requires": {
         "foreach": "2.0.5",
         "object-keys": "1.0.11"
+      }
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "delegates": {
@@ -271,6 +493,16 @@
         "minimist": "1.2.0",
         "underscore": "1.8.3",
         "update-section": "0.3.3"
+      }
+    },
+    "doctrine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
       }
     },
     "dom-serializer": {
@@ -376,6 +608,192 @@
       "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
       "dev": true
     },
+    "eslint": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.8.0.tgz",
+      "integrity": "sha1-Ip7w41Tg5h2DfHqA/fuoJeGZgV4=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.2.3",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.1.0",
+        "concat-stream": "1.6.0",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.0.0",
+        "eslint-scope": "3.7.1",
+        "espree": "3.5.1",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.5",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.4.1",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "espree": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.2",
+        "acorn-jsx": "3.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
     "expand-template": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.0.3.tgz",
@@ -403,16 +821,90 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
+    "external-editor": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19",
+        "jschardet": "1.5.1",
+        "tmp": "0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
     "function-bind": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "gauge": {
@@ -447,6 +939,57 @@
         "minimatch": "0.3.0"
       }
     },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
     "growl": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
@@ -471,6 +1014,12 @@
         "ansi-regex": "2.1.1"
       }
     },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -491,6 +1040,34 @@
         "readable-stream": "2.3.3"
       }
     },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -502,6 +1079,96 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.1.0",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.0.5",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "is-alphabetical": {
       "version": "1.0.1",
@@ -598,6 +1265,36 @@
       "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
       "dev": true
     },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -605,6 +1302,15 @@
       "dev": true,
       "requires": {
         "has": "1.0.1"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
       }
     },
     "is-string": {
@@ -623,6 +1329,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "jade": {
@@ -647,6 +1359,59 @@
           "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
           "dev": true
         }
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "jschardet": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lodash": {
@@ -695,6 +1460,12 @@
         "nan": "2.6.2",
         "prebuild-install": "2.2.1"
       }
+    },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
     },
     "minimatch": {
       "version": "0.3.0",
@@ -782,10 +1553,22 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "nan": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "node-abi": {
@@ -873,10 +1656,39 @@
         "wrappy": "1.0.2"
       }
     },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "parse-entities": {
@@ -893,10 +1705,49 @@
         "is-hexadecimal": "1.0.1"
       }
     },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
     "platform": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
       "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0=",
+      "dev": true
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prebuild-install": {
@@ -921,6 +1772,12 @@
         "xtend": "4.0.1"
       }
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
     "prettier": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.7.4.tgz",
@@ -931,6 +1788,18 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "pump": {
@@ -1034,10 +1903,94 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
     "ret": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.14.tgz",
       "integrity": "sha1-WMY2g3sS4WH4o4DPCBxqIw/RZk4="
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -1054,6 +2007,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "sigmund": {
@@ -1078,6 +2046,29 @@
         "unzip-response": "1.0.2",
         "xtend": "4.0.1"
       }
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.0.3",
@@ -1141,6 +2132,88 @@
       "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
       "dev": true
     },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.2.3",
+        "ajv-keywords": "2.1.0",
+        "chalk": "2.1.0",
+        "lodash": "4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "tar-fs": {
       "version": "1.15.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
@@ -1165,11 +2238,32 @@
         "xtend": "4.0.1"
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "tmatch": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
       "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
       "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
     },
     "to-iso-string": {
       "version": "0.0.2",
@@ -1201,6 +2295,12 @@
       "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y=",
       "dev": true
     },
+    "tryit": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1209,6 +2309,21 @@
       "requires": {
         "safe-buffer": "5.1.1"
       }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typescript": {
       "version": "2.4.2",
@@ -1301,6 +2416,15 @@
         "defaults": "1.0.3"
       }
     },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
@@ -1310,16 +2434,37 @@
         "string-width": "1.0.2"
       }
     },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "test": "mocha test/*.test.js",
     "doctoc": "doctoc --notitle README.md",
     "profile": "bin/nearleyc.js test/grammars/parens.ne > test/grammars/parens.js && node test/profile.js",
+    "fix": "npm run eslintfix; npm run prettier",
+    "eslintfix": "eslint --fix lib/; eslint --fix test/; eslint --fix bin/",
     "prettier": "prettier --tab-width 4 --write lib/**/*.js test/**/*.js bin/**/*.js"
   },
   "author": "Hardmath123",
@@ -50,6 +52,7 @@
     "benchr": "^3.2.0",
     "coffee-script": "^1.10.0",
     "doctoc": "^1.3.0",
+    "eslint": "^4.8.0",
     "expect": "^1.20.2",
     "microtime": "^2.1.2",
     "mocha": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "benchmark": "benchr test/benchmark.js",
     "test": "mocha test/*.test.js",
     "doctoc": "doctoc --notitle README.md",
-    "profile": "bin/nearleyc.js test/grammars/parens.ne > test/grammars/parens.js && node test/profile.js"
+    "profile": "bin/nearleyc.js test/grammars/parens.ne > test/grammars/parens.js && node test/profile.js",
+    "prettier": "prettier --tab-width 4 --write lib/**/*.js test/**/*.js bin/**/*.js"
   },
   "author": "Hardmath123",
   "contributors": "https://github.com/Hardmath123/nearley/graphs/contributors",
@@ -53,6 +54,7 @@
     "microtime": "^2.1.2",
     "mocha": "^2.5.3",
     "moo": "^0.3.2",
+    "prettier": "^1.7.4",
     "typescript": "^2.3.4"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,41 @@
+{
+  "env": {
+    "node": true,
+    "mocha": true,
+    "commonjs": true,
+    "es6": true
+  },
+  "rules": {
+    "indent": [
+      "error",
+      4
+    ],
+    "prefer-arrow-callback": "error",
+    "semi": ["error", "always"],
+    "no-var": "error",
+    "prefer-const": ["error", {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+    }],
+    "no-console": ["off"],
+    "comma-dangle": ["off"],
+    "keyword-spacing": "error",
+    "quotes": [
+      "warn",
+      "double"
+    ],
+    "no-trailing-spaces": [
+      "error", {
+        "skipBlankLines": false
+      }
+    ],
+    "eol-last": "error",
+    "no-irregular-whitespace": ["error", {
+      "skipComments": false
+    }],
+    "space-infix-ops": ["error", {
+      "int32Hint": false
+    }]
+  },
+  "extends": ["eslint:recommended"]
+}

--- a/test/_shared.js
+++ b/test/_shared.js
@@ -1,32 +1,32 @@
-var path = require("path");
+const path = require("path");
 
-var nearley = require("../lib/nearley");
+const nearley = require("../lib/nearley");
 
-var Compile = require("../lib/compile");
-var parserGrammar = nearley.Grammar.fromCompiled(
+const Compile = require("../lib/compile");
+const parserGrammar = nearley.Grammar.fromCompiled(
     require("../lib/nearley-language-bootstrapped")
 );
-var generate = require("../lib/generate");
+const generate = require("../lib/generate");
 
 function parse(grammar, input) {
-    var p = new nearley.Parser(grammar);
+    const p = new nearley.Parser(grammar);
     p.feed(input);
     return p.results;
 }
 
 function nearleyc(source) {
     // parse
-    var results = parse(parserGrammar, source);
+    const results = parse(parserGrammar, source);
 
     // compile
-    var c = Compile(results[0], {});
+    const c = Compile(results[0], {});
 
     // generate
     return generate(c, "grammar");
 }
 
 function compile(source) {
-    var compiledGrammar = nearleyc(source);
+    const compiledGrammar = nearleyc(source);
 
     // eval
     return evalGrammar(compiledGrammar);
@@ -43,13 +43,13 @@ function requireFromString(source) {
 }
 */
 function requireFromString(source) {
-    var module = { exports: null };
+    const module = { exports: null };
     eval(source);
     return module.exports;
 }
 
 function evalGrammar(compiledGrammar) {
-    var exports = requireFromString(compiledGrammar);
+    const exports = requireFromString(compiledGrammar);
     return new nearley.Grammar.fromCompiled(exports);
 }
 

--- a/test/_shared.js
+++ b/test/_shared.js
@@ -1,11 +1,12 @@
+var path = require("path");
 
-var path = require('path');
+var nearley = require("../lib/nearley");
 
-var nearley = require('../lib/nearley');
-
-var Compile = require('../lib/compile');
-var parserGrammar = nearley.Grammar.fromCompiled(require('../lib/nearley-language-bootstrapped'));
-var generate = require('../lib/generate');
+var Compile = require("../lib/compile");
+var parserGrammar = nearley.Grammar.fromCompiled(
+    require("../lib/nearley-language-bootstrapped")
+);
+var generate = require("../lib/generate");
 
 function parse(grammar, input) {
     var p = new nearley.Parser(grammar);
@@ -21,7 +22,7 @@ function nearleyc(source) {
     var c = Compile(results[0], {});
 
     // generate
-    return generate(c, 'grammar');
+    return generate(c, "grammar");
 }
 
 function compile(source) {
@@ -42,8 +43,8 @@ function requireFromString(source) {
 }
 */
 function requireFromString(source) {
-    var module = {exports: null};
-    eval(source)
+    var module = { exports: null };
+    eval(source);
     return module.exports;
 }
 
@@ -56,6 +57,5 @@ module.exports = {
     compile: compile,
     nearleyc: nearleyc,
     evalGrammar: evalGrammar,
-    parse: parse,
+    parse: parse
 };
-

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,11 +1,10 @@
+const fs = require("fs");
 
-const fs = require('fs');
-
-const nearley = require('../lib/nearley');
-const {compile} = require('./_shared');
+const nearley = require("../lib/nearley");
+const { compile } = require("./_shared");
 
 function read(filename) {
-    return fs.readFileSync(filename, 'utf-8');
+    return fs.readFileSync(filename, "utf-8");
 }
 
 function makeParser(neFile) {
@@ -18,40 +17,36 @@ function makeParser(neFile) {
 
     return function parse(input) {
         if (grammar === null) {
-            throw 'grammar error';
+            throw "grammar error";
         }
         var p = new nearley.Parser(grammar);
         p.feed(input);
         return p.results;
-    }
+    };
 }
-
 
 // Define benchmarks
 
-suite('calculator', () => {
-  const exampleFile = 'ln (3 + 2*(8/e - sin(pi/5)))'
+suite("calculator", () => {
+    const exampleFile = "ln (3 + 2*(8/e - sin(pi/5)))";
 
-  const parse = makeParser('examples/calculator/arithmetic.ne')
-  benchmark('nearley', () => parse(exampleFile))
+    const parse = makeParser("examples/calculator/arithmetic.ne");
+    benchmark("nearley", () => parse(exampleFile));
+});
 
-})
+suite("json", () => {
+    const jsonFile = read("test/grammars/sample1k.json");
 
-suite('json', () => {
-  const jsonFile = read('test/grammars/sample1k.json')
+    const parse = makeParser("examples/json.ne");
+    benchmark("nearley", () => parse(jsonFile));
 
-  const parse = makeParser('examples/json.ne')
-  benchmark('nearley', () => parse(jsonFile))
+    //benchmark('native JSON 😛', () => JSON.parse(jsonFile))
+});
 
-  //benchmark('native JSON 😛', () => JSON.parse(jsonFile))
+suite("tosh", () => {
+    const toshFile =
+        "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))";
 
-})
-
-suite('tosh', () => {
-  const toshFile = 'set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))'
-
-  const parse = makeParser('examples/tosh.ne')
-  benchmark('nearley', () => parse(toshFile))
-
-})
-
+    const parse = makeParser("examples/tosh.ne");
+    benchmark("nearley", () => parse(toshFile));
+});

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -8,7 +8,7 @@ function read(filename) {
 }
 
 function makeParser(neFile) {
-    var grammar;
+    let grammar;
     try {
         grammar = compile(read(neFile));
     } catch (e) {
@@ -19,7 +19,7 @@ function makeParser(neFile) {
         if (grammar === null) {
             throw "grammar error";
         }
-        var p = new nearley.Parser(grammar);
+        const p = new nearley.Parser(grammar);
         p.feed(input);
         return p.results;
     };

--- a/test/external.js
+++ b/test/external.js
@@ -1,28 +1,33 @@
+const fs = require("fs");
+const path = require("path");
+const child_process = require("child_process");
 
-const fs = require('fs')
-const path = require('path')
-const child_process = require('child_process')
-
-const root = 'test/'
+const root = "test/";
 
 function sh(cmd) {
-    return child_process.spawnSync(cmd, {shell: true, encoding: 'utf-8', stdio: 'pipe', cwd: root})
+    return child_process.spawnSync(cmd, {
+        shell: true,
+        encoding: "utf-8",
+        stdio: "pipe",
+        cwd: root
+    });
 }
 
-var highestId = 0
+var highestId = 0;
 function externalNearleyc(input, ext, flags = []) {
-    const outPath = 'tmp.' + path.basename(input) + (++highestId)
-    const {stderr, stdout} = sh(`../bin/nearleyc.js ${flags.join(' ')} ${input} -o ${outPath}${ext}`);
-    return {outPath, stderr, stdout}
+    const outPath = "tmp." + path.basename(input) + ++highestId;
+    const { stderr, stdout } = sh(
+        `../bin/nearleyc.js ${flags.join(" ")} ${input} -o ${outPath}${ext}`
+    );
+    return { outPath, stderr, stdout };
 }
 
 function cleanup() {
     for (let name of fs.readdirSync(root)) {
         if (/^tmp\./.test(name)) {
-            fs.unlinkSync(path.join(root, name))
+            fs.unlinkSync(path.join(root, name));
         }
     }
 }
 
-module.exports = {sh, externalNearleyc, cleanup}
-
+module.exports = { sh, externalNearleyc, cleanup };

--- a/test/external.js
+++ b/test/external.js
@@ -13,7 +13,7 @@ function sh(cmd) {
     });
 }
 
-var highestId = 0;
+let highestId = 0;
 function externalNearleyc(input, ext, flags = []) {
     const outPath = "tmp." + path.basename(input) + ++highestId;
     const { stderr, stdout } = sh(
@@ -23,7 +23,7 @@ function externalNearleyc(input, ext, flags = []) {
 }
 
 function cleanup() {
-    for (let name of fs.readdirSync(root)) {
+    for (const name of fs.readdirSync(root)) {
         if (/^tmp\./.test(name)) {
             fs.unlinkSync(path.join(root, name));
         }

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -5,7 +5,7 @@ const lint = require("../lib/lint");
 describe("Linter", function() {
     var mockGrammar, mockOpts, writeSpy;
 
-    beforeEach(function () {
+    beforeEach(function() {
         mockGrammar = {
             rules: [],
             config: {}
@@ -16,37 +16,35 @@ describe("Linter", function() {
             }
         };
         writeSpy = expect.spyOn(mockOpts.out, "write");
-    })
+    });
 
-    it("runs without warnings on empty rules", function () {
+    it("runs without warnings on empty rules", function() {
         lint(mockGrammar, mockOpts);
         expect(writeSpy).toNotHaveBeenCalled();
     });
 
-    it("warns about undefined symbol", function () {
-        mockGrammar.rules = [
-            {name: "a", symbols: ["non-existent"]}
-        ];
+    it("warns about undefined symbol", function() {
+        mockGrammar.rules = [{ name: "a", symbols: ["non-existent"] }];
         lint(mockGrammar, mockOpts);
         expect(writeSpy).toHaveBeenCalled();
     });
 
-    it("doesn't warn about defined symbol", function () {
-        mockGrammar.rules =  [
-            {name: "a", symbols: []},
-            {name: "b", symbols: ["a"]}
+    it("doesn't warn about defined symbol", function() {
+        mockGrammar.rules = [
+            { name: "a", symbols: [] },
+            { name: "b", symbols: ["a"] }
         ];
         lint(mockGrammar, mockOpts);
         expect(writeSpy).toNotHaveBeenCalled();
     });
 
-    it("doesn't warn about duplicate symbol", function () {
-        mockGrammar.rules =  [
-            {name: "a", symbols: []},
-            {name: "a", symbols: []},
-            {name: "b", symbols: ["a"]}
+    it("doesn't warn about duplicate symbol", function() {
+        mockGrammar.rules = [
+            { name: "a", symbols: [] },
+            { name: "a", symbols: [] },
+            { name: "b", symbols: ["a"] }
         ];
         lint(mockGrammar, mockOpts);
         expect(writeSpy).toNotHaveBeenCalled();
     });
-})
+});

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -2,10 +2,10 @@ const expect = require("expect");
 
 const lint = require("../lib/lint");
 
-describe("Linter", function() {
-    var mockGrammar, mockOpts, writeSpy;
+describe("Linter", () => {
+    let mockGrammar, mockOpts, writeSpy;
 
-    beforeEach(function() {
+    beforeEach(() => {
         mockGrammar = {
             rules: [],
             config: {}
@@ -18,18 +18,18 @@ describe("Linter", function() {
         writeSpy = expect.spyOn(mockOpts.out, "write");
     });
 
-    it("runs without warnings on empty rules", function() {
+    it("runs without warnings on empty rules", () => {
         lint(mockGrammar, mockOpts);
         expect(writeSpy).toNotHaveBeenCalled();
     });
 
-    it("warns about undefined symbol", function() {
+    it("warns about undefined symbol", () => {
         mockGrammar.rules = [{ name: "a", symbols: ["non-existent"] }];
         lint(mockGrammar, mockOpts);
         expect(writeSpy).toHaveBeenCalled();
     });
 
-    it("doesn't warn about defined symbol", function() {
+    it("doesn't warn about defined symbol", () => {
         mockGrammar.rules = [
             { name: "a", symbols: [] },
             { name: "b", symbols: ["a"] }
@@ -38,7 +38,7 @@ describe("Linter", function() {
         expect(writeSpy).toNotHaveBeenCalled();
     });
 
-    it("doesn't warn about duplicate symbol", function() {
+    it("doesn't warn about duplicate symbol", () => {
         mockGrammar.rules = [
             { name: "a", symbols: [] },
             { name: "a", symbols: [] },

--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -1,175 +1,243 @@
+const fs = require("fs");
+const expect = require("expect");
 
-const fs = require('fs');
-const expect = require('expect');
-
-const nearley = require('../lib/nearley');
-const {compile, evalGrammar, parse, nearleyc} = require('./_shared');
-const {sh, externalNearleyc, cleanup} = require('./external');
+const nearley = require("../lib/nearley");
+const { compile, evalGrammar, parse, nearleyc } = require("./_shared");
+const { sh, externalNearleyc, cleanup } = require("./external");
 
 function read(filename) {
-    return fs.readFileSync(filename, 'utf-8');
+    return fs.readFileSync(filename, "utf-8");
 }
 
 describe("bin/nearleyc", function() {
-    after(cleanup)
+    after(cleanup);
 
-    it('builds for ES5', function() {
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/parens.ne", '.js');
+    it("builds for ES5", function() {
+        const { outPath, stdout, stderr } = externalNearleyc(
+            "grammars/parens.ne",
+            ".js"
+        );
         expect(stderr).toBe("");
         expect(stdout).toBe("");
-        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
+        const grammar = nearley.Grammar.fromCompiled(
+            require(`./${outPath}.js`)
+        );
     });
 
-    it('builds for CoffeeScript', function() {
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/coffeescript-test.ne", ".coffee");
+    it("builds for CoffeeScript", function() {
+        const { outPath, stdout, stderr } = externalNearleyc(
+            "grammars/coffeescript-test.ne",
+            ".coffee"
+        );
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         sh(`coffee -c ${outPath}.coffee`);
-        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
-        expect(parse(grammar, "ABCDEFZ12309")).toEqual([ [ 'ABCDEFZ', '12309' ] ]);
+        const grammar = nearley.Grammar.fromCompiled(
+            require(`./${outPath}.js`)
+        );
+        expect(parse(grammar, "ABCDEFZ12309")).toEqual([["ABCDEFZ", "12309"]]);
     });
 
-    it('builds for TypeScript', function() {
+    it("builds for TypeScript", function() {
         this.timeout(10000); // It takes a while to run tsc!
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/typescript-test.ne", ".ts");
+        const { outPath, stdout, stderr } = externalNearleyc(
+            "grammars/typescript-test.ne",
+            ".ts"
+        );
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         sh(`tsc ${outPath}.ts`);
-        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
-        expect(parse(grammar, "<123>")).toEqual([ [ '<', '123', '>' ] ]);
+        const grammar = nearley.Grammar.fromCompiled(
+            require(`./${outPath}.js`)
+        );
+        expect(parse(grammar, "<123>")).toEqual([["<", "123", ">"]]);
     });
 
-    it('builds modules in folders', function() {
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/folder-test.ne", '.js');
+    it("builds modules in folders", function() {
+        const { outPath, stdout, stderr } = externalNearleyc(
+            "grammars/folder-test.ne",
+            ".js"
+        );
         expect(stderr).toBe("");
         expect(stdout).toBe("");
-        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
+        const grammar = nearley.Grammar.fromCompiled(
+            require(`./${outPath}.js`)
+        );
     });
 
-    it('builds modules with multiple includes of the same file', function() {
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/multi-include-test.ne", '.js');
+    it("builds modules with multiple includes of the same file", function() {
+        const { outPath, stdout, stderr } = externalNearleyc(
+            "grammars/multi-include-test.ne",
+            ".js"
+        );
         expect(stderr).toBe("");
         expect(stdout).toBe("");
-        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
+        const grammar = nearley.Grammar.fromCompiled(
+            require(`./${outPath}.js`)
+        );
     });
 
-    it("warns about undefined symbol", function () {
-        const {stdout, stderr} = externalNearleyc("grammars/warning-undefined-test.ne", '.js');
+    it("warns about undefined symbol", function() {
+        const { stdout, stderr } = externalNearleyc(
+            "grammars/warning-undefined-test.ne",
+            ".js"
+        );
         expect(stderr).toNotBe("");
         expect(stdout).toBe("");
     });
 
-    it("doesn't warn when used with the --quiet option", function () {
-        const {stdout, stderr} = externalNearleyc("grammars/warning-undefined-test.ne", '.js', ['--quiet']);
+    it("doesn't warn when used with the --quiet option", function() {
+        const {
+            stdout,
+            stderr
+        } = externalNearleyc("grammars/warning-undefined-test.ne", ".js", [
+            "--quiet"
+        ]);
         expect(stderr).toBe("");
         expect(stdout).toBe("");
     });
+});
 
-
-})
-
-describe('nearleyc', function() {
-
-    it('calculator example', function() {
+describe("nearleyc", function() {
+    it("calculator example", function() {
         const arith = compile(read("examples/calculator/arithmetic.ne"));
-        expect(parse(arith, "ln (3 + 2*(8/e - sin(pi/5)))")).toEqual([ Math.log(3 + 2*(8/Math.exp(1) - Math.sin(Math.PI/5))) ]);
+        expect(parse(arith, "ln (3 + 2*(8/e - sin(pi/5)))")).toEqual([
+            Math.log(3 + 2 * (8 / Math.exp(1) - Math.sin(Math.PI / 5)))
+        ]);
     });
 
-    it('csscolor example', function() {
+    it("csscolor example", function() {
         const cssc = compile(read("examples/csscolor.ne"));
-        expect(parse(cssc, "#FF00FF")).toEqual([{r: 0xff, g: 0x00, b: 0xff}]);
-        expect(parse(cssc, "#8A7")).toEqual([{r: 0x88, g: 0xaa, b: 0x77}]);
-        expect(parse(cssc, "rgb(99,66,33)")).toEqual([{r: 99, g: 66, b: 33}]);
-        expect(parse(cssc, "hsl(99,66,33)")).toEqual([{h: 99, s: 66, l: 33}]);
-        expect(function() { parse(cssc, "#badcolor"); }).toThrow()
+        expect(parse(cssc, "#FF00FF")).toEqual([{ r: 0xff, g: 0x00, b: 0xff }]);
+        expect(parse(cssc, "#8A7")).toEqual([{ r: 0x88, g: 0xaa, b: 0x77 }]);
+        expect(parse(cssc, "rgb(99,66,33)")).toEqual([{ r: 99, g: 66, b: 33 }]);
+        expect(parse(cssc, "hsl(99,66,33)")).toEqual([{ h: 99, s: 66, l: 33 }]);
+        expect(function() {
+            parse(cssc, "#badcolor");
+        }).toThrow();
     });
 
-    it('exponential whitespace bug', function() {
-        compile(read('test/grammars/indentation.ne'));
+    it("exponential whitespace bug", function() {
+        compile(read("test/grammars/indentation.ne"));
     });
 
-    it('nullable whitespace bug', function() {
+    it("nullable whitespace bug", function() {
         const wsb = compile(read("test/grammars/whitespace.ne"));
-        expect(parse(wsb, "(x)")).toEqual(
-            [ [ [ [ '(', null, [ [ [ [ 'x' ] ] ] ], null, ')' ] ] ] ]);
+        expect(parse(wsb, "(x)")).toEqual([
+            [[["(", null, [[[["x"]]]], null, ")"]]]
+        ]);
     });
 
-    it('percent bug', function() {
-        compile(read('test/grammars/percent.ne'));
+    it("percent bug", function() {
+        compile(read("test/grammars/percent.ne"));
     });
 
-    it('tokens', function() {
+    it("tokens", function() {
         const tokc = compile(read("examples/token.ne"));
-        expect(parse(tokc, [123, 456, " ", 789])).toEqual([ [123, [ [ 456, " ", 789 ] ]] ]);
+        expect(parse(tokc, [123, 456, " ", 789])).toEqual([
+            [123, [[456, " ", 789]]]
+        ]);
     });
 
-    it('leo bug', function() {
+    it("leo bug", function() {
         const leo = compile(read("test/grammars/leobug.ne"));
-        expect(parse(leo, "baab")).toEqual(
-            [ [ 'b', [], 'a', [], 'a', [ 'b' ] ],
-            [ 'b', [], 'a', [], 'a', [ 'b', [] ] ] ]);
+        expect(parse(leo, "baab")).toEqual([
+            ["b", [], "a", [], "a", ["b"]],
+            ["b", [], "a", [], "a", ["b", []]]
+        ]);
     });
 
     var json;
-    it('json example compiles', function() {
+    it("json example compiles", function() {
         json = compile(read("examples/json.ne"));
     });
-    it('json test1', function() {
-        const test1 = read('test/grammars/test1.json');
+    it("json test1", function() {
+        const test1 = read("test/grammars/test1.json");
         expect(parse(json, test1)).toEqual([JSON.parse(test1)]);
     });
-    it('json test2', function() {
-        const test2 = read('test/grammars/test2.json');
+    it("json test2", function() {
+        const test2 = read("test/grammars/test2.json");
         expect(parse(json, test2)).toEqual([JSON.parse(test2)]);
     });
 
-    it('tosh example', function() {
+    it("tosh example", function() {
         const tosh = compile(read("examples/tosh.ne"));
-        expect(parse(tosh, "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))"))
-            .toEqual([["setVar:to:","foo",["*",["*",2,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]],["-",1,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]]]]]);
+        expect(
+            parse(
+                tosh,
+                "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))"
+            )
+        ).toEqual([
+            [
+                "setVar:to:",
+                "foo",
+                [
+                    "*",
+                    [
+                        "*",
+                        2,
+                        [
+                            "computeFunction:of:",
+                            "e ^",
+                            ["+", ["*", ["readVariable", "foo"], -0.05], 0.5]
+                        ]
+                    ],
+                    [
+                        "-",
+                        1,
+                        [
+                            "computeFunction:of:",
+                            "e ^",
+                            ["+", ["*", ["readVariable", "foo"], -0.05], 0.5]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
     });
 
-    it('classic crontab', function() {
+    it("classic crontab", function() {
         // Try compiling the grammar
         const classicCrontab = compile(read("examples/classic_crontab.ne"));
         // Try parsing crontab file using the newly generated parser
-        const crontabTest = read('test/grammars/classic_crontab.test');
-        const crontabResults = read('test/grammars/classic_crontab.results');
-        expect(parse(classicCrontab, crontabTest)).toEqual([JSON.parse(crontabResults)]);
+        const crontabTest = read("test/grammars/classic_crontab.test");
+        const crontabResults = read("test/grammars/classic_crontab.results");
+        expect(parse(classicCrontab, crontabTest)).toEqual([
+            JSON.parse(crontabResults)
+        ]);
     });
 
-    it('parentheses', function() {
+    it("parentheses", function() {
         // Try compiling the grammar
         const parentheses = compile(read("examples/parentheses.ne"));
         const passCases = [
-            '()',
-            '[(){}<>]',
-            '[(((<>)()({})())(()())(())[])]',
-            '<<[([])]>([(<>[]{}{}<>())[{}[][]{}{}[]<>[]{}<>{}<>[]<>{}()][[][][]()()()]({})<[]>{(){}()<>}(<>[])]())({})>'
+            "()",
+            "[(){}<>]",
+            "[(((<>)()({})())(()())(())[])]",
+            "<<[([])]>([(<>[]{}{}<>())[{}[][]{}{}[]<>[]{}<>{}<>[]<>{}()][[][][]()()()]({})<[]>{(){}()<>}(<>[])]())({})>"
         ];
 
         for (let i in passCases) {
             expect(parse(parentheses, passCases[i])).toEqual([true]);
         }
 
-        const failCases = [
-            ' ',
-            '[}',
-            '[(){}><]',
-            '(((())))(()))'
-        ];
+        const failCases = [" ", "[}", "[(){}><]", "(((())))(()))"];
 
         for (let i in failCases) {
-            expect(function() { parse(parentheses, failCases[i]); }).toThrow()
+            expect(function() {
+                parse(parentheses, failCases[i]);
+            }).toThrow();
         }
 
         // These are invalid inputs but the parser will not complain
-        expect(parse(parentheses, '')).toEqual([]);
-        expect(parse(parentheses, '((((())))(())()')).toEqual([]);
+        expect(parse(parentheses, "")).toEqual([]);
+        expect(parse(parentheses, "((((())))(())()")).toEqual([]);
     });
 
-    it('case-insensitive strings', function() {
-        const caseinsensitive = compile(read("test/grammars/caseinsensitive.ne"));
+    it("case-insensitive strings", function() {
+        const caseinsensitive = compile(
+            read("test/grammars/caseinsensitive.ne")
+        );
         const passCases = [
             "Les rêves des amoureux sont comme le bon vin!",
             "LES RÊVES DES AMOUREUX SONT COMME LE BON VIN!",
@@ -178,32 +246,29 @@ describe('nearleyc', function() {
         ];
         passCases.forEach(function(c) {
             const p = parse(caseinsensitive, c);
-            expect(p.length).toBe(1)
+            expect(p.length).toBe(1);
             expect(p[0].toUpperCase()).toBe(passCases[1]);
         });
     });
-
 });
 
-describe('builtins', () => {
-
-    it('generate includes id', () => {
+describe("builtins", () => {
+    it("generate includes id", () => {
         const source = nearleyc(`
         X -> "hat" {% id %}
-        `)
-        expect(source.indexOf('function id(')).toNotBe(-1)
-        const g = evalGrammar(source)
-        expect(parse(g, "hat")).toEqual(["hat"])
-    })
+        `);
+        expect(source.indexOf("function id(")).toNotBe(-1);
+        const g = evalGrammar(source);
+        expect(parse(g, "hat")).toEqual(["hat"]);
+    });
 
     // TODO fix docs?
-    it.skip('nuller', () => {
+    it.skip("nuller", () => {
         //@builtin "postprocessors.ne"
         const source = nearleyc(`
         ws -> " " {% nuller %}
-        `)
-        const g = evalGrammar(source)
-        expect(parse(g, " ")).toEqual([null])
-    })
-})
-
+        `);
+        const g = evalGrammar(source);
+        expect(parse(g, " ")).toEqual([null]);
+    });
+});

--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -9,10 +9,10 @@ function read(filename) {
     return fs.readFileSync(filename, "utf-8");
 }
 
-describe("bin/nearleyc", function() {
+describe("bin/nearleyc", () => {
     after(cleanup);
 
-    it("builds for ES5", function() {
+    it("builds for ES5", () => {
         const { outPath, stdout, stderr } = externalNearleyc(
             "grammars/parens.ne",
             ".js"
@@ -24,7 +24,7 @@ describe("bin/nearleyc", function() {
         );
     });
 
-    it("builds for CoffeeScript", function() {
+    it("builds for CoffeeScript", () => {
         const { outPath, stdout, stderr } = externalNearleyc(
             "grammars/coffeescript-test.ne",
             ".coffee"
@@ -53,7 +53,7 @@ describe("bin/nearleyc", function() {
         expect(parse(grammar, "<123>")).toEqual([["<", "123", ">"]]);
     });
 
-    it("builds modules in folders", function() {
+    it("builds modules in folders", () => {
         const { outPath, stdout, stderr } = externalNearleyc(
             "grammars/folder-test.ne",
             ".js"
@@ -65,7 +65,7 @@ describe("bin/nearleyc", function() {
         );
     });
 
-    it("builds modules with multiple includes of the same file", function() {
+    it("builds modules with multiple includes of the same file", () => {
         const { outPath, stdout, stderr } = externalNearleyc(
             "grammars/multi-include-test.ne",
             ".js"
@@ -77,7 +77,7 @@ describe("bin/nearleyc", function() {
         );
     });
 
-    it("warns about undefined symbol", function() {
+    it("warns about undefined symbol", () => {
         const { stdout, stderr } = externalNearleyc(
             "grammars/warning-undefined-test.ne",
             ".js"
@@ -86,7 +86,7 @@ describe("bin/nearleyc", function() {
         expect(stdout).toBe("");
     });
 
-    it("doesn't warn when used with the --quiet option", function() {
+    it("doesn't warn when used with the --quiet option", () => {
         const {
             stdout,
             stderr
@@ -98,48 +98,48 @@ describe("bin/nearleyc", function() {
     });
 });
 
-describe("nearleyc", function() {
-    it("calculator example", function() {
+describe("nearleyc", () => {
+    it("calculator example", () => {
         const arith = compile(read("examples/calculator/arithmetic.ne"));
         expect(parse(arith, "ln (3 + 2*(8/e - sin(pi/5)))")).toEqual([
             Math.log(3 + 2 * (8 / Math.exp(1) - Math.sin(Math.PI / 5)))
         ]);
     });
 
-    it("csscolor example", function() {
+    it("csscolor example", () => {
         const cssc = compile(read("examples/csscolor.ne"));
         expect(parse(cssc, "#FF00FF")).toEqual([{ r: 0xff, g: 0x00, b: 0xff }]);
         expect(parse(cssc, "#8A7")).toEqual([{ r: 0x88, g: 0xaa, b: 0x77 }]);
         expect(parse(cssc, "rgb(99,66,33)")).toEqual([{ r: 99, g: 66, b: 33 }]);
         expect(parse(cssc, "hsl(99,66,33)")).toEqual([{ h: 99, s: 66, l: 33 }]);
-        expect(function() {
+        expect(() => {
             parse(cssc, "#badcolor");
         }).toThrow();
     });
 
-    it("exponential whitespace bug", function() {
+    it("exponential whitespace bug", () => {
         compile(read("test/grammars/indentation.ne"));
     });
 
-    it("nullable whitespace bug", function() {
+    it("nullable whitespace bug", () => {
         const wsb = compile(read("test/grammars/whitespace.ne"));
         expect(parse(wsb, "(x)")).toEqual([
             [[["(", null, [[[["x"]]]], null, ")"]]]
         ]);
     });
 
-    it("percent bug", function() {
+    it("percent bug", () => {
         compile(read("test/grammars/percent.ne"));
     });
 
-    it("tokens", function() {
+    it("tokens", () => {
         const tokc = compile(read("examples/token.ne"));
         expect(parse(tokc, [123, 456, " ", 789])).toEqual([
             [123, [[456, " ", 789]]]
         ]);
     });
 
-    it("leo bug", function() {
+    it("leo bug", () => {
         const leo = compile(read("test/grammars/leobug.ne"));
         expect(parse(leo, "baab")).toEqual([
             ["b", [], "a", [], "a", ["b"]],
@@ -147,20 +147,20 @@ describe("nearleyc", function() {
         ]);
     });
 
-    var json;
-    it("json example compiles", function() {
+    let json;
+    it("json example compiles", () => {
         json = compile(read("examples/json.ne"));
     });
-    it("json test1", function() {
+    it("json test1", () => {
         const test1 = read("test/grammars/test1.json");
         expect(parse(json, test1)).toEqual([JSON.parse(test1)]);
     });
-    it("json test2", function() {
+    it("json test2", () => {
         const test2 = read("test/grammars/test2.json");
         expect(parse(json, test2)).toEqual([JSON.parse(test2)]);
     });
 
-    it("tosh example", function() {
+    it("tosh example", () => {
         const tosh = compile(read("examples/tosh.ne"));
         expect(
             parse(
@@ -196,7 +196,7 @@ describe("nearleyc", function() {
         ]);
     });
 
-    it("classic crontab", function() {
+    it("classic crontab", () => {
         // Try compiling the grammar
         const classicCrontab = compile(read("examples/classic_crontab.ne"));
         // Try parsing crontab file using the newly generated parser
@@ -207,7 +207,7 @@ describe("nearleyc", function() {
         ]);
     });
 
-    it("parentheses", function() {
+    it("parentheses", () => {
         // Try compiling the grammar
         const parentheses = compile(read("examples/parentheses.ne"));
         const passCases = [
@@ -217,14 +217,14 @@ describe("nearleyc", function() {
             "<<[([])]>([(<>[]{}{}<>())[{}[][]{}{}[]<>[]{}<>{}<>[]<>{}()][[][][]()()()]({})<[]>{(){}()<>}(<>[])]())({})>"
         ];
 
-        for (let i in passCases) {
+        for (const i in passCases) {
             expect(parse(parentheses, passCases[i])).toEqual([true]);
         }
 
         const failCases = [" ", "[}", "[(){}><]", "(((())))(()))"];
 
-        for (let i in failCases) {
-            expect(function() {
+        for (const i in failCases) {
+            expect(() => {
                 parse(parentheses, failCases[i]);
             }).toThrow();
         }
@@ -234,7 +234,7 @@ describe("nearleyc", function() {
         expect(parse(parentheses, "((((())))(())()")).toEqual([]);
     });
 
-    it("case-insensitive strings", function() {
+    it("case-insensitive strings", () => {
         const caseinsensitive = compile(
             read("test/grammars/caseinsensitive.ne")
         );
@@ -244,7 +244,7 @@ describe("nearleyc", function() {
             "leS RêVeS DeS AmOuReUx sOnT CoMmE Le bOn vIn!",
             "LEs rÊvEs dEs aMoUrEuX SoNt cOmMe lE BoN ViN!"
         ];
-        passCases.forEach(function(c) {
+        passCases.forEach(c => {
             const p = parse(caseinsensitive, c);
             expect(p.length).toBe(1);
             expect(p[0].toUpperCase()).toBe(passCases[1]);

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -8,42 +8,42 @@ function read(filename) {
     return fs.readFileSync(filename, "utf-8");
 }
 
-describe("Parser", function() {
-    let testGrammar = compile(`
+describe("Parser", () => {
+    const testGrammar = compile(`
     y -> x:+
     x -> [a-z0-9] | "\\n"
     `);
 
-    it("shows line number in errors", function() {
+    it("shows line number in errors", () => {
         expect(() => parse(testGrammar, "abc\n12!")).toThrow(
             "invalid syntax at line 2 col 3:\n" + "\n" + "  12!\n" + "    ^"
         );
     });
 
-    it("shows token index in errors", function() {
+    it("shows token index in errors", () => {
         expect(() => parse(testGrammar, ["1", "2", "!"])).toThrow(
             "invalid syntax at index 2"
         );
     });
 
-    var tosh = compile(read("examples/tosh.ne"));
+    const tosh = compile(read("examples/tosh.ne"));
 
-    it("can save state", function() {
-        let first = "say 'hello'";
-        let second = " for 2 secs";
-        let p = new nearley.Parser(tosh, { keepHistory: true });
+    it("can save state", () => {
+        const first = "say 'hello'";
+        const second = " for 2 secs";
+        const p = new nearley.Parser(tosh, { keepHistory: true });
         p.feed(first);
         expect(p.current).toBe(11);
         expect(p.table.length).toBe(12);
-        var col = p.save();
+        const col = p.save();
         expect(col.index).toBe(11);
         expect(col.lexerState.col).toBe(first.length);
     });
 
-    it("can rewind", function() {
-        let first = "say 'hello'";
-        let second = " for 2 secs";
-        let p = new nearley.Parser(tosh, { keepHistory: true });
+    it("can rewind", () => {
+        const first = "say 'hello'";
+        const second = " for 2 secs";
+        const p = new nearley.Parser(tosh, { keepHistory: true });
         p.feed(first);
         expect(p.current).toBe(11);
         expect(p.table.length).toBe(12);
@@ -58,17 +58,17 @@ describe("Parser", function() {
         expect(p.results).toEqual([["say:", "hello"]]);
     });
 
-    it("won't rewind without `keepHistory` option", function() {
-        let p = new nearley.Parser(tosh, {});
+    it("won't rewind without `keepHistory` option", () => {
+        const p = new nearley.Parser(tosh, {});
         expect(() => p.rewind()).toThrow();
     });
 
-    it("restores line numbers", function() {
-        let p = new nearley.Parser(testGrammar);
+    it("restores line numbers", () => {
+        const p = new nearley.Parser(testGrammar);
         p.feed("abc\n");
         expect(p.save().lexerState.line).toBe(2);
         p.feed("123\n");
-        var col = p.save();
+        const col = p.save();
         expect(col.lexerState.line).toBe(3);
         p.feed("q");
         p.restore(col);
@@ -76,10 +76,10 @@ describe("Parser", function() {
         p.feed("z");
     });
 
-    it("restores column number", function() {
-        let p = new nearley.Parser(testGrammar);
+    it("restores column number", () => {
+        const p = new nearley.Parser(testGrammar);
         p.feed("foo\nbar");
-        var col = p.save();
+        const col = p.save();
         expect(col.lexerState.line).toBe(2);
         expect(col.lexerState.col).toBe(3);
         p.feed("123");

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,103 +1,96 @@
+const fs = require("fs");
+const expect = require("expect");
 
-const fs = require('fs');
-const expect = require('expect');
-
-const nearley = require('../lib/nearley');
-const {compile, evalGrammar, parse} = require('./_shared');
+const nearley = require("../lib/nearley");
+const { compile, evalGrammar, parse } = require("./_shared");
 
 function read(filename) {
-    return fs.readFileSync(filename, 'utf-8');
+    return fs.readFileSync(filename, "utf-8");
 }
 
-
-describe('Parser', function() {
-
+describe("Parser", function() {
     let testGrammar = compile(`
     y -> x:+
     x -> [a-z0-9] | "\\n"
-    `)
+    `);
 
-    it('shows line number in errors', function() {
-      expect(() => parse(testGrammar, 'abc\n12!')).toThrow(
-        'invalid syntax at line 2 col 3:\n' +
-        '\n' +
-        '  12!\n' +
-        '    ^'
-      )
-    })
+    it("shows line number in errors", function() {
+        expect(() => parse(testGrammar, "abc\n12!")).toThrow(
+            "invalid syntax at line 2 col 3:\n" + "\n" + "  12!\n" + "    ^"
+        );
+    });
 
-    it('shows token index in errors', function() {
-      expect(() => parse(testGrammar, ['1', '2', '!'])).toThrow(
-        'invalid syntax at index 2'
-      )
-    })
+    it("shows token index in errors", function() {
+        expect(() => parse(testGrammar, ["1", "2", "!"])).toThrow(
+            "invalid syntax at index 2"
+        );
+    });
 
     var tosh = compile(read("examples/tosh.ne"));
 
-    it('can save state', function() {
+    it("can save state", function() {
         let first = "say 'hello'";
         let second = " for 2 secs";
         let p = new nearley.Parser(tosh, { keepHistory: true });
         p.feed(first);
-        expect(p.current).toBe(11)
-        expect(p.table.length).toBe(12)
+        expect(p.current).toBe(11);
+        expect(p.table.length).toBe(12);
         var col = p.save();
-        expect(col.index).toBe(11)
-        expect(col.lexerState.col).toBe(first.length)
+        expect(col.index).toBe(11);
+        expect(col.lexerState.col).toBe(first.length);
     });
 
-    it('can rewind', function() {
+    it("can rewind", function() {
         let first = "say 'hello'";
         let second = " for 2 secs";
         let p = new nearley.Parser(tosh, { keepHistory: true });
         p.feed(first);
-        expect(p.current).toBe(11)
-        expect(p.table.length).toBe(12)
+        expect(p.current).toBe(11);
+        expect(p.table.length).toBe(12);
 
         p.feed(second);
 
         p.rewind(first.length);
 
-        expect(p.current).toBe(11)
-        expect(p.table.length).toBe(12)
+        expect(p.current).toBe(11);
+        expect(p.table.length).toBe(12);
 
-        expect(p.results).toEqual([['say:', 'hello']]);
+        expect(p.results).toEqual([["say:", "hello"]]);
     });
 
     it("won't rewind without `keepHistory` option", function() {
         let p = new nearley.Parser(tosh, {});
-        expect(() => p.rewind()).toThrow()
-    })
-
-    it('restores line numbers', function() {
-      let p = new nearley.Parser(testGrammar);
-      p.feed('abc\n')
-      expect(p.save().lexerState.line).toBe(2)
-      p.feed('123\n')
-      var col = p.save();
-      expect(col.lexerState.line).toBe(3)
-      p.feed('q')
-      p.restore(col);
-      expect(p.lexer.line).toBe(3)
-      p.feed('z')
+        expect(() => p.rewind()).toThrow();
     });
 
-    it('restores column number', function() {
-      let p = new nearley.Parser(testGrammar);
-      p.feed('foo\nbar')
-      var col = p.save();
-      expect(col.lexerState.line).toBe(2)
-      expect(col.lexerState.col).toBe(3)
-      p.feed('123');
-      expect(p.lexerState.col).toBe(6)
+    it("restores line numbers", function() {
+        let p = new nearley.Parser(testGrammar);
+        p.feed("abc\n");
+        expect(p.save().lexerState.line).toBe(2);
+        p.feed("123\n");
+        var col = p.save();
+        expect(col.lexerState.line).toBe(3);
+        p.feed("q");
+        p.restore(col);
+        expect(p.lexer.line).toBe(3);
+        p.feed("z");
+    });
 
-      p.restore(col);
-      expect(p.lexerState.line).toBe(2)
-      expect(p.lexerState.col).toBe(3)
-      p.feed('456')
-      expect(p.lexerState.col).toBe(6)
+    it("restores column number", function() {
+        let p = new nearley.Parser(testGrammar);
+        p.feed("foo\nbar");
+        var col = p.save();
+        expect(col.lexerState.line).toBe(2);
+        expect(col.lexerState.col).toBe(3);
+        p.feed("123");
+        expect(p.lexerState.col).toBe(6);
+
+        p.restore(col);
+        expect(p.lexerState.line).toBe(2);
+        expect(p.lexerState.col).toBe(3);
+        p.feed("456");
+        expect(p.lexerState.col).toBe(6);
     });
 
     // TODO: moo save/restore
-
 });

--- a/test/profile.js
+++ b/test/profile.js
@@ -1,51 +1,55 @@
-var nearley = require('../lib/nearley.js');
-var parserGrammar = require('./grammars/parens.js');
+var nearley = require("../lib/nearley.js");
+var parserGrammar = require("./grammars/parens.js");
 function nspace(n) {
-	var out = "";
-	for (var i=0; i<n; i++) {
-		out += " ";
-	}
-	return out;
+    var out = "";
+    for (var i = 0; i < n; i++) {
+        out += " ";
+    }
+    return out;
 }
 
 function profile(n, type) {
-	var test = "";
-	for (var i=0; i<n; i++) {
-		test += "(";
-	}
-	test += "acowcowcowcowcowcowcowcowcow";
-	for (var i=0; i<n; i++) {
-		test += ")";
-	}
-	var starttime = process.hrtime();
-	var startmemory = process.memoryUsage().heapUsed;
-	var p = new nearley.Parser(parserGrammar.ParserRules, parserGrammar.ParserStart).feed(test);
-	console.assert(p.results[0]);
-	switch (type) {
-	case "TIME":
-		var tdiff = process.hrtime(starttime)[1];
-		console.log(
-			nspace(Math.round(tdiff/1e9  *80))+"*" // how much of one second
-		);
-		break;
-	case "MEMO":
-		var mdiff = process.memoryUsage().heapUsed - startmemory;
-		console.log(
-			nspace(Math.round(mdiff/1e8  *80)) + "+"
-		);
-	}
+    var test = "";
+    for (var i = 0; i < n; i++) {
+        test += "(";
+    }
+    test += "acowcowcowcowcowcowcowcowcow";
+    for (var i = 0; i < n; i++) {
+        test += ")";
+    }
+    var starttime = process.hrtime();
+    var startmemory = process.memoryUsage().heapUsed;
+    var p = new nearley.Parser(
+        parserGrammar.ParserRules,
+        parserGrammar.ParserStart
+    ).feed(test);
+    console.assert(p.results[0]);
+    switch (type) {
+        case "TIME":
+            var tdiff = process.hrtime(starttime)[1];
+            console.log(
+                nspace(Math.round(tdiff / 1e9 * 80)) + "*" // how much of one second
+            );
+            break;
+        case "MEMO":
+            var mdiff = process.memoryUsage().heapUsed - startmemory;
+            console.log(nspace(Math.round(mdiff / 1e8 * 80)) + "+");
+    }
 }
 
 console.log("Nearley test.");
 console.log("=============");
-console.log("Tests operate on the grammar p -> \"(\" p \")\" | [a-z]");
-console.log("An input of size n is 2n+1 characters long, and of the form (((...a...))).");
+console.log('Tests operate on the grammar p -> "(" p ")" | [a-z]');
+console.log(
+    "An input of size n is 2n+1 characters long, and of the form (((...a...)))."
+);
 console.log();
-
 
 console.log("Running time tests.");
 console.log("-------------------");
-console.log("Each star corresponds to the time taken to parse an input of that size with a recursive grammar.");
+console.log(
+    "Each star corresponds to the time taken to parse an input of that size with a recursive grammar."
+);
 console.log();
 console.log("SCALE");
 console.log(nspace(20) + "0.25s");
@@ -53,18 +57,21 @@ console.log(nspace(40) + "0.50s");
 console.log(nspace(60) + "0.75s");
 console.log(nspace(80) + "1.00s");
 
-for (var i=0; i<5e4; i+=2e3) {
-	if (i%1e4 === 0) {
-		console.log(i);
-	}
-	profile(i, "TIME");
+for (var i = 0; i < 5e4; i += 2e3) {
+    if (i % 1e4 === 0) {
+        console.log(i);
+    }
+    profile(i, "TIME");
 }
-
 
 console.log("Running memory tests.");
 console.log("-------------------");
-console.log("Each star corresponds to the memory taken to parse an input of that size with a recursive grammar.");
-console.log("Occasional outliers may be caused by gc runs. Nearley profiling doesn't explicitly call the gc before each run.");
+console.log(
+    "Each star corresponds to the memory taken to parse an input of that size with a recursive grammar."
+);
+console.log(
+    "Occasional outliers may be caused by gc runs. Nearley profiling doesn't explicitly call the gc before each run."
+);
 console.log();
 console.log("SCALE");
 console.log(nspace(20) + "025MB");
@@ -72,9 +79,9 @@ console.log(nspace(40) + "050MB");
 console.log(nspace(60) + "075MB");
 console.log(nspace(80) + "100MB");
 
-for (var i=0; i<5e4; i+=2e3) {
-	if (i%1e4 === 0) {
-		console.log(i);
-	}
-	profile(i, "MEMO");
+for (var i = 0; i < 5e4; i += 2e3) {
+    if (i % 1e4 === 0) {
+        console.log(i);
+    }
+    profile(i, "MEMO");
 }

--- a/test/profile.js
+++ b/test/profile.js
@@ -1,15 +1,15 @@
-var nearley = require("../lib/nearley.js");
-var parserGrammar = require("./grammars/parens.js");
+const nearley = require("../lib/nearley.js");
+const parserGrammar = require("./grammars/parens.js");
 function nspace(n) {
-    var out = "";
-    for (var i = 0; i < n; i++) {
+    let out = "";
+    for (let i = 0; i < n; i++) {
         out += " ";
     }
     return out;
 }
 
 function profile(n, type) {
-    var test = "";
+    let test = "";
     for (var i = 0; i < n; i++) {
         test += "(";
     }
@@ -17,9 +17,9 @@ function profile(n, type) {
     for (var i = 0; i < n; i++) {
         test += ")";
     }
-    var starttime = process.hrtime();
-    var startmemory = process.memoryUsage().heapUsed;
-    var p = new nearley.Parser(
+    const starttime = process.hrtime();
+    const startmemory = process.memoryUsage().heapUsed;
+    const p = new nearley.Parser(
         parserGrammar.ParserRules,
         parserGrammar.ParserStart
     ).feed(test);


### PR DESCRIPTION
As discussed in #310

This adds an npm script: `npm fix`, that will reformat the code using prettier
and a bit of eslint (mainly to fix use of `const` and `=>` in tests). Eslint errors that can not be automatically fixed are currently printed but otherwise ignored (exit code is 0).

If you think it's a good idea it's best to merge all pending pull-requests first at which point I can rebase this and it can be merged and we will have more consistent code going forward.