### PR TITLE
Code formatter

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,6 +44,7 @@ Before submitting a **pull request**, have you done the following?
   without your change to detect possible bugs, and included the output in your
   pull request as a separate comment. Parsing is tricky, and innocent changes
   can sometimes kill performance. :-(
+* Run the code formatter with `npm run fmt`, to ensure consistent code style.
 * _Not_ introduced any new dependencies. Check in with a maintainer if you
   think you need a dependency.
 * Please don't introduce style changes either--these introduce noise which

--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -16,11 +16,11 @@ var opts = nomnom
     .script("nearley-railroad")
     .option("file", {
         position: 0,
-        help: "A grammar .ne file (default stdin)"
+        help: "A grammar .ne file (default stdin)",
     })
     .option("out", {
         abbr: "o",
-        help: "File to output to (default stdout)."
+        help: "File to output to (default stdout).",
     })
     .option("version", {
         abbr: "v",
@@ -28,8 +28,9 @@ var opts = nomnom
         help: "Print version and exit",
         callback: function() {
             return require("../package.json").version;
-        }
-    }).parse();
+        },
+    })
+    .parse();
 
 var input = opts.file ? fs.createReadStream(opts.file) : process.stdin;
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
@@ -102,18 +103,18 @@ function railroad(grm) {
     }
 
     return [
-      "<!DOCTYPE html>",
-      "<html>",
+        "<!DOCTYPE html>",
+        "<html>",
         "<head>",
-          '<meta charset="UTF-8">',
-          '<style type="text/css">',
-            style.toString(),
-          "</style>",
+        '<meta charset="UTF-8">',
+        '<style type="text/css">',
+        style.toString(),
+        "</style>",
         "</head>",
         "<body>",
-          diagrams.join("\n"),
+        diagrams.join("\n"),
         "</body>",
-      "</html>"
+        "</html>",
     ].join("\n");
 }
 

--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
 try {
-  var rr = require("railroad-diagrams");
-} catch(e) {
-  // optional dependency not fullfilled
-  console.log('Error: When you installed nearley, the dependency "railroad-diagrams" failed to install. Try running "npm install -g nearley" to re-install nearley. If that doesn\'t fix the problem, please file an issue on the nearley GitHub repository.')
-  process.exit(1)
+    var rr = require("railroad-diagrams");
+} catch (e) {
+    // optional dependency not fullfilled
+    console.log(
+        'Error: When you installed nearley, the dependency "railroad-diagrams" failed to install. Try running "npm install -g nearley" to re-install nearley. If that doesn\'t fix the problem, please file an issue on the nearley GitHub repository.'
+    );
+    process.exit(1);
 }
 
 var fs = require("fs");
@@ -47,24 +49,18 @@ function railroad(grm) {
     });
 
     var style = fs.readFileSync(
-        path.join(
-            path.dirname(require.resolve("railroad-diagrams")),
-            "railroad-diagrams.css"
-        )
+        path.join(path.dirname(require.resolve("railroad-diagrams")), "railroad-diagrams.css")
     );
 
     var diagrams = Object.keys(rules).map(function(r) {
-        return [
-          "<h1><code>" + r + "</code></h1>",
-          "<div>",
-            diagram(r).toString(),
-          "</div>"
-        ].join("\n");
+        return ["<h1><code>" + r + "</code></h1>", "<div>", diagram(r).toString(), "</div>"].join(
+            "\n"
+        );
     });
 
     function diagram(name) {
         var selectedrules = rules[name];
-        var outer = {subexpression: selectedrules};
+        var outer = { subexpression: selectedrules };
 
         function renderTok(tok) {
             // ctx translated to correct position already
@@ -72,15 +68,15 @@ function railroad(grm) {
                 return new rr.Choice(0, tok.subexpression.map(renderTok));
             } else if (tok.ebnf) {
                 switch (tok.modifier) {
-                case ":+":
-                    return new rr.OneOrMore(renderTok(tok.ebnf));
-                    break;
-                case ":*":
-                    return new rr.ZeroOrMore(renderTok(tok.ebnf));
-                    break;
-                case ":?":
-                    return new rr.Optional(renderTok(tok.ebnf));
-                    break;
+                    case ":+":
+                        return new rr.OneOrMore(renderTok(tok.ebnf));
+                        break;
+                    case ":*":
+                        return new rr.ZeroOrMore(renderTok(tok.ebnf));
+                        break;
+                    case ":?":
+                        return new rr.Optional(renderTok(tok.ebnf));
+                        break;
                 }
             } else if (tok.literal) {
                 return new rr.Terminal(JSON.stringify(tok.literal));
@@ -90,7 +86,7 @@ function railroad(grm) {
                 return new rr.Comment("Pas implementé.");
             } else if (tok.tokens) {
                 return new rr.Sequence(tok.tokens.map(renderTok));
-            } else if (typeof(tok) === "string") {
+            } else if (typeof tok === "string") {
                 return new rr.NonTerminal(tok);
             } else if (tok.constructor === RegExp) {
                 return new rr.Terminal(tok.toString());
@@ -122,12 +118,10 @@ var nearley = require("../lib/nearley.js");
 var StreamWrapper = require("../lib/stream.js");
 var parserGrammar = new require("../lib/nearley-language-bootstrapped.js");
 var parser = new nearley.Parser(parserGrammar.ParserRules, parserGrammar.ParserStart);
-input
-    .pipe(new StreamWrapper(parser))
-    .on("finish", function() {
-        if (parser.results[0]) {
-            output.write(railroad(parser.results[0]));
-        } else {
-            process.stderr.write("SyntaxError: unexpected EOF\n");
-        }
-    });
+input.pipe(new StreamWrapper(parser)).on("finish", function() {
+    if (parser.results[0]) {
+        output.write(railroad(parser.results[0]));
+    } else {
+        process.stderr.write("SyntaxError: unexpected EOF\n");
+    }
+});

--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -1,33 +1,33 @@
 #!/usr/bin/env node
 
 try {
-  var rr = require('railroad-diagrams');
+  var rr = require("railroad-diagrams");
 } catch(e) {
   // optional dependency not fullfilled
   console.log('Error: When you installed nearley, the dependency "railroad-diagrams" failed to install. Try running "npm install -g nearley" to re-install nearley. If that doesn\'t fix the problem, please file an issue on the nearley GitHub repository.')
   process.exit(1)
 }
 
-var fs = require('fs');
-var path = require('path');
-var nomnom = require('nomnom');
+var fs = require("fs");
+var path = require("path");
+var nomnom = require("nomnom");
 
 var opts = nomnom
-    .script('nearley-railroad')
-    .option('file', {
+    .script("nearley-railroad")
+    .option("file", {
         position: 0,
         help: "A grammar .ne file (default stdin)"
     })
-    .option('out', {
-        abbr: 'o',
+    .option("out", {
+        abbr: "o",
         help: "File to output to (default stdout)."
     })
-    .option('version', {
-        abbr: 'v',
+    .option("version", {
+        abbr: "v",
         flag: true,
         help: "Print version and exit",
         callback: function() {
-            return require('../package.json').version;
+            return require("../package.json").version;
         }
     }).parse();
 
@@ -47,18 +47,18 @@ function railroad(grm) {
 
     var style = fs.readFileSync(
         path.join(
-            path.dirname(require.resolve('railroad-diagrams')),
-            'railroad-diagrams.css'
+            path.dirname(require.resolve("railroad-diagrams")),
+            "railroad-diagrams.css"
         )
     );
 
     var diagrams = Object.keys(rules).map(function(r) {
         return [
-          '<h1><code>' + r + '</code></h1>',
-          '<div>',
+          "<h1><code>" + r + "</code></h1>",
+          "<div>",
             diagram(r).toString(),
-          '</div>'
-        ].join('\n');
+          "</div>"
+        ].join("\n");
     });
 
     function diagram(name) {
@@ -89,7 +89,7 @@ function railroad(grm) {
                 return new rr.Comment("Pas implementé.");
             } else if (tok.tokens) {
                 return new rr.Sequence(tok.tokens.map(renderTok));
-            } else if (typeof(tok) === 'string') {
+            } else if (typeof(tok) === "string") {
                 return new rr.NonTerminal(tok);
             } else if (tok.constructor === RegExp) {
                 return new rr.Terminal(tok.toString());
@@ -102,31 +102,31 @@ function railroad(grm) {
     }
 
     return [
-      '<!DOCTYPE html>',
-      '<html>',
-        '<head>',
+      "<!DOCTYPE html>",
+      "<html>",
+        "<head>",
           '<meta charset="UTF-8">',
           '<style type="text/css">',
             style.toString(),
-          '</style>',
-        '</head>',
-        '<body>',
-          diagrams.join('\n'),
-        '</body>',
-      '</html>'
-    ].join('\n');
+          "</style>",
+        "</head>",
+        "<body>",
+          diagrams.join("\n"),
+        "</body>",
+      "</html>"
+    ].join("\n");
 }
 
-var nearley = require('../lib/nearley.js');
-var StreamWrapper = require('../lib/stream.js');
-var parserGrammar = new require('../lib/nearley-language-bootstrapped.js');
+var nearley = require("../lib/nearley.js");
+var StreamWrapper = require("../lib/stream.js");
+var parserGrammar = new require("../lib/nearley-language-bootstrapped.js");
 var parser = new nearley.Parser(parserGrammar.ParserRules, parserGrammar.ParserStart);
 input
     .pipe(new StreamWrapper(parser))
-    .on('finish', function() {
+    .on("finish", function() {
         if (parser.results[0]) {
             output.write(railroad(parser.results[0]));
         } else {
-            process.stderr.write('SyntaxError: unexpected EOF\n');
+            process.stderr.write("SyntaxError: unexpected EOF\n");
         }
     });

--- a/bin/nearley-test.js
+++ b/bin/nearley-test.js
@@ -48,40 +48,39 @@ var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
 var filename = require("path").resolve(opts.file);
 var grammar = nearley.Grammar.fromCompiled(require(filename));
-if (opts.start) grammar.start = opts.start
+if (opts.start) grammar.start = opts.start;
 var parser = new nearley.Parser(grammar, {
     keepHistory: true,
 });
 
-var writeTable = function (writeStream, parser) {
+var writeTable = function(writeStream, parser) {
     writeStream.write("Table length: " + parser.table.length + "\n");
     writeStream.write("Number of parses: " + parser.results.length + "\n");
     writeStream.write("Parse Charts");
-    parser.table.forEach(function (column, index) {
+    parser.table.forEach(function(column, index) {
         writeStream.write("\nChart: " + index++ + "\n");
         var stateNumber = 0;
-        column.states.forEach(function (state, stateIndex) {
+        column.states.forEach(function(state, stateIndex) {
             writeStream.write(stateIndex + ": " + state.toString() + "\n");
-        })
-    })
-    writeStream.write("\n\nParse results: \n");
-}
-
-var writeResults = function (writeStream, parser) {
-    writeStream.write(require("util").inspect(parser.results, {colors: !opts.quiet, depth: null}));
-    writeStream.write("\n");
-}
-
-if (typeof(opts.input) === "undefined") {
-    process.stdin
-        .pipe(new StreamWrapper(parser))
-        .on("finish", function() {
-            if (!opts.quiet) writeTable(output, parser);
-            writeResults(output, parser);
         });
+    });
+    writeStream.write("\n\nParse results: \n");
+};
+
+var writeResults = function(writeStream, parser) {
+    writeStream.write(
+        require("util").inspect(parser.results, { colors: !opts.quiet, depth: null })
+    );
+    writeStream.write("\n");
+};
+
+if (typeof opts.input === "undefined") {
+    process.stdin.pipe(new StreamWrapper(parser)).on("finish", function() {
+        if (!opts.quiet) writeTable(output, parser);
+        writeResults(output, parser);
+    });
 } else {
     parser.feed(opts.input);
     if (!opts.quiet) writeTable(output, parser);
     writeResults(output, parser);
 }
-

--- a/bin/nearley-test.js
+++ b/bin/nearley-test.js
@@ -4,49 +4,49 @@
    or, node bin/nearleythere.js examples/js/AycockHorspool.js --input "aa" 
  */
 
-var fs = require('fs');
-var nearley = require('../lib/nearley.js');
-var nomnom = require('nomnom');
-var StreamWrapper = require('../lib/stream.js');
+var fs = require("fs");
+var nearley = require("../lib/nearley.js");
+var nomnom = require("nomnom");
+var StreamWrapper = require("../lib/stream.js");
 
 var opts = nomnom
-    .script('nearley-test')
-    .option('file', {
+    .script("nearley-test")
+    .option("file", {
         position: 0,
         help: "A grammar .js file",
         required: true,
     })
-    .option('input', {
-        abbr: 'i',
+    .option("input", {
+        abbr: "i",
         help: "An input string to parse (if not provided then read from stdin)",
-        type: 'string',
+        type: "string",
     })
-    .option('start', {
-        abbr: 's',
+    .option("start", {
+        abbr: "s",
         help: "An optional start symbol (if not provided then use the parser start symbol)",
     })
-    .option('out', {
-        abbr: 'o',
+    .option("out", {
+        abbr: "o",
         help: "File to output to (defaults to stdout)",
     })
-    .option('quiet', {
-        abbr: 'q',
+    .option("quiet", {
+        abbr: "q",
         flag: true,
         help: "Output parse results only (hide Earley table)",
     })
-    .option('version', {
-        abbr: 'v',
+    .option("version", {
+        abbr: "v",
         flag: true,
         help: "Print version and exit",
         callback: function() {
-            return require('../package.json').version;
+            return require("../package.json").version;
         }
     })
     .parse();
 
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
-var filename = require('path').resolve(opts.file);
+var filename = require("path").resolve(opts.file);
 var grammar = nearley.Grammar.fromCompiled(require(filename));
 if (opts.start) grammar.start = opts.start
 var parser = new nearley.Parser(grammar, {
@@ -68,14 +68,14 @@ var writeTable = function (writeStream, parser) {
 }
 
 var writeResults = function (writeStream, parser) {
-    writeStream.write(require('util').inspect(parser.results, {colors: !opts.quiet, depth: null}));
+    writeStream.write(require("util").inspect(parser.results, {colors: !opts.quiet, depth: null}));
     writeStream.write("\n");
 }
 
 if (typeof(opts.input) === "undefined") {
     process.stdin
         .pipe(new StreamWrapper(parser))
-        .on('finish', function() {
+        .on("finish", function() {
             if (!opts.quiet) writeTable(output, parser);
             writeResults(output, parser);
         });

--- a/bin/nearley-test.js
+++ b/bin/nearley-test.js
@@ -40,7 +40,7 @@ var opts = nomnom
         help: "Print version and exit",
         callback: function() {
             return require("../package.json").version;
-        }
+        },
     })
     .parse();
 

--- a/bin/nearley-unparse.js
+++ b/bin/nearley-unparse.js
@@ -53,19 +53,17 @@ function gen(grammar, name) {
 
     while (stack.length > 0) {
         var currentname = stack.pop();
-        if (typeof(currentname) === "string") {
+        if (typeof currentname === "string") {
             var goodrules = grammar.ParserRules.filter(function(x) {
                 return x.name === currentname;
             });
             if (goodrules.length > 0) {
-                var chosen = goodrules[
-                    Math.floor(Math.random()*goodrules.length)
-                ];
-                for (var i=chosen.symbols.length-1; i>=0; i--) {
+                var chosen = goodrules[Math.floor(Math.random() * goodrules.length)];
+                for (var i = chosen.symbols.length - 1; i >= 0; i--) {
                     stack.push(chosen.symbols[i]);
                 }
             } else {
-                throw new Error("Nothing matches rule: "+currentname+"!");
+                throw new Error("Nothing matches rule: " + currentname + "!");
             }
         } else if (currentname.test) {
             var c = new randexp(currentname).gen();
@@ -92,7 +90,7 @@ function gen2(grammar, name, depth) {
     function synth_nt(name, depth) {
         var good_rules = [];
         var min_min_depth = Infinity;
-        for (var i=0; i<rules.length; i++) {
+        for (var i = 0; i < rules.length; i++) {
             min_depths_rule = [];
             var size = min_depth_rule(i, []);
             if (rules[i].name === name) {
@@ -103,20 +101,23 @@ function gen2(grammar, name, depth) {
             }
         }
         if (good_rules.length === 0) {
-            throw ("No strings in your grammar have depth "+depth+" (and " +
-                   "none are shallower). Try increasing -d to at least "+
-                   (min_min_depth+1) + ".");
+            throw "No strings in your grammar have depth " +
+                depth +
+                " (and " +
+                "none are shallower). Try increasing -d to at least " +
+                (min_min_depth + 1) +
+                ".";
         }
 
-        var r = good_rules[Math.floor(Math.random()*good_rules.length)];
+        var r = good_rules[Math.floor(Math.random() * good_rules.length)];
         return synth_rule(r, depth);
     }
     function synth_rule(idx, depth) {
         var ret = "";
-        for (var i=0; i<rules[idx].symbols.length; i++) {
+        for (var i = 0; i < rules[idx].symbols.length; i++) {
             var tok = rules[idx].symbols[i];
-            if (typeof(tok) === "string") {
-                ret += synth_nt(tok, depth-1);
+            if (typeof tok === "string") {
+                ret += synth_nt(tok, depth - 1);
             } else if (tok.test) {
                 ret += new randexp(tok).gen();
             } else if (tok.literal) {
@@ -130,7 +131,7 @@ function gen2(grammar, name, depth) {
             return +Infinity;
         }
         var d = +Infinity;
-        for (var i=0; i<rules.length; i++) {
+        for (var i = 0; i < rules.length; i++) {
             if (rules[i].name === name) {
                 d = Math.min(d, min_depth_rule(i, [name].concat(visited)));
             }
@@ -141,10 +142,10 @@ function gen2(grammar, name, depth) {
         if (min_depths_rule[idx] !== undefined) return min_depths_rule[idx];
 
         var d = 1;
-        for (var i=0; i<rules[idx].symbols.length; i++) {
+        for (var i = 0; i < rules[idx].symbols.length; i++) {
             var tok = rules[idx].symbols[i];
-            if (typeof(tok) === "string") {
-                d = Math.max(d, 1+min_depth_nt(tok, visited));
+            if (typeof tok === "string") {
+                d = Math.max(d, 1 + min_depth_nt(tok, visited));
             }
         }
         min_depths_rule[idx] = d;
@@ -155,10 +156,8 @@ function gen2(grammar, name, depth) {
     return ret;
 }
 
-
-
 // the main loop
-for (var i=0; i<parseInt(opts.count); i++) {
+for (var i = 0; i < parseInt(opts.count); i++) {
     if (opts.depth === -1) {
         gen(grammar, opts.start ? opts.start : grammar.ParserStart);
     } else {

--- a/bin/nearley-unparse.js
+++ b/bin/nearley-unparse.js
@@ -19,12 +19,12 @@ var opts = nomnom
     .option("count", {
         abbr: "n",
         help: "The number of samples to generate (separated by \\n).",
-        default: 1
+        default: 1,
     })
     .option("depth", {
         abbr: "d",
         help: 'The depth bound of each sample. Defaults to -1, which means "unbounded".',
-        default: -1
+        default: -1,
     })
     .option("out", {
         abbr: "o",
@@ -36,7 +36,7 @@ var opts = nomnom
         help: "Print version and exit",
         callback: function() {
             return require("../package.json").version;
-        }
+        },
     })
     .parse();
 

--- a/bin/nearley-unparse.js
+++ b/bin/nearley-unparse.js
@@ -1,48 +1,48 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
-var nearley = require('../lib/nearley.js');
-var nomnom = require('nomnom');
-var randexp = require('randexp');
+var fs = require("fs");
+var nearley = require("../lib/nearley.js");
+var nomnom = require("nomnom");
+var randexp = require("randexp");
 
 var opts = nomnom
-    .script('nearley-unparse')
-    .option('file', {
+    .script("nearley-unparse")
+    .option("file", {
         position: 0,
         help: "A grammar .js file",
         required: true,
     })
-    .option('start', {
-        abbr: 's',
+    .option("start", {
+        abbr: "s",
         help: "An optional start symbol (if not provided then use the parser start symbol)",
     })
-    .option('count', {
-        abbr: 'n',
-        help: 'The number of samples to generate (separated by \\n).',
+    .option("count", {
+        abbr: "n",
+        help: "The number of samples to generate (separated by \\n).",
         default: 1
     })
-    .option('depth', {
-        abbr: 'd',
+    .option("depth", {
+        abbr: "d",
         help: 'The depth bound of each sample. Defaults to -1, which means "unbounded".',
         default: -1
     })
-    .option('out', {
-        abbr: 'o',
+    .option("out", {
+        abbr: "o",
         help: "File to output to (defaults to stdout)",
     })
-    .option('version', {
-        abbr: 'v',
+    .option("version", {
+        abbr: "v",
         flag: true,
         help: "Print version and exit",
         callback: function() {
-            return require('../package.json').version;
+            return require("../package.json").version;
         }
     })
     .parse();
 
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
-var grammar = new require(require('path').resolve(opts.file));
+var grammar = new require(require("path").resolve(opts.file));
 
 function gen(grammar, name) {
     // The first-generation generator. It just spews out stuff randomly, and is
@@ -53,7 +53,7 @@ function gen(grammar, name) {
 
     while (stack.length > 0) {
         var currentname = stack.pop();
-        if (typeof(currentname) === 'string') {
+        if (typeof(currentname) === "string") {
             var goodrules = grammar.ParserRules.filter(function(x) {
                 return x.name === currentname;
             });
@@ -82,8 +82,8 @@ function gen(grammar, name) {
 function gen2(grammar, name, depth) {
     // I guess you could call this the second-generation generator.
     // All it does is bound its output by a certain depth without having to
-    // backtrack. It doesn't give guarantees on being uniformly random, but
-    // that's doable if we *really* need it (by converting min_depth_rule, a
+    // backtrack. It doesn"t give guarantees on being uniformly random, but
+    // that"s doable if we *really* need it (by converting min_depth_rule, a
     // predicate, into something that counts the number of trees of depth d).
 
     var rules = grammar.ParserRules;
@@ -115,7 +115,7 @@ function gen2(grammar, name, depth) {
         var ret = "";
         for (var i=0; i<rules[idx].symbols.length; i++) {
             var tok = rules[idx].symbols[i];
-            if (typeof(tok) === 'string') {
+            if (typeof(tok) === "string") {
                 ret += synth_nt(tok, depth-1);
             } else if (tok.test) {
                 ret += new randexp(tok).gen();
@@ -143,7 +143,7 @@ function gen2(grammar, name, depth) {
         var d = 1;
         for (var i=0; i<rules[idx].symbols.length; i++) {
             var tok = rules[idx].symbols[i];
-            if (typeof(tok) === 'string') {
+            if (typeof(tok) === "string") {
                 d = Math.max(d, 1+min_depth_nt(tok, visited));
             }
         }

--- a/bin/nearleyc.js
+++ b/bin/nearleyc.js
@@ -1,63 +1,63 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
-var nearley = require('../lib/nearley.js');
-var nomnom = require('nomnom');
-var Compile = require('../lib/compile.js');
-var StreamWrapper = require('../lib/stream.js');
+var fs = require("fs");
+var nearley = require("../lib/nearley.js");
+var nomnom = require("nomnom");
+var Compile = require("../lib/compile.js");
+var StreamWrapper = require("../lib/stream.js");
 
 var opts = nomnom
-    .script('nearleyc')
-    .option('file', {
+    .script("nearleyc")
+    .option("file", {
         position: 0,
         help: "An input .ne file (if not provided then read from stdin)",
     })
-    .option('out', {
-        abbr: 'o',
+    .option("out", {
+        abbr: "o",
         help: "File to output to (defaults to stdout)",
     })
-    .option('export', {
-        abbr: 'e',
+    .option("export", {
+        abbr: "e",
         help: "Variable to set the parser to",
         default: "grammar"
     })
-    .option('quiet', {
-        abbr: 'q',
+    .option("quiet", {
+        abbr: "q",
         flag: true,
         help: "Suppress the linter."
     })
-    .option('nojs', {
+    .option("nojs", {
         flag: true,
         default: false,
-        help: "Don't compile postprocessors (for testing)."
+        help: 'Don"t compile postprocessors (for testing).'
     })
-    .option('version', {
-        abbr: 'v',
+    .option("version", {
+        abbr: "v",
         flag: true,
         help: "Print version and exit",
         callback: function() {
-            return require('../package.json').version;
+            return require("../package.json").version;
         }
     })
     .parse();
 
-var version = require('../package.json').version;
+var version = require("../package.json").version;
 
 var input = opts.file ? fs.createReadStream(opts.file) : process.stdin;
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
-var parserGrammar = nearley.Grammar.fromCompiled(require('../lib/nearley-language-bootstrapped.js'));
+var parserGrammar = nearley.Grammar.fromCompiled(require("../lib/nearley-language-bootstrapped.js"));
 var parser = new nearley.Parser(parserGrammar);
-var generate = require('../lib/generate.js');
-var lint = require('../lib/lint.js');
+var generate = require("../lib/generate.js");
+var lint = require("../lib/lint.js");
 
 input
     .pipe(new StreamWrapper(parser))
-    .on('finish', function() {
+    .on("finish", function() {
         var c = Compile(
             parser.results[0],
             Object.assign({version: version}, opts)
         );
-        if (!opts.quiet) lint(c, {'out': process.stderr, 'version': version});
+        if (!opts.quiet) lint(c, {"out": process.stderr, "version": version});
         output.write(generate(c, opts.export));
     });

--- a/bin/nearleyc.js
+++ b/bin/nearleyc.js
@@ -19,17 +19,17 @@ var opts = nomnom
     .option("export", {
         abbr: "e",
         help: "Variable to set the parser to",
-        default: "grammar"
+        default: "grammar",
     })
     .option("quiet", {
         abbr: "q",
         flag: true,
-        help: "Suppress the linter."
+        help: "Suppress the linter.",
     })
     .option("nojs", {
         flag: true,
         default: false,
-        help: 'Don"t compile postprocessors (for testing).'
+        help: 'Don"t compile postprocessors (for testing).',
     })
     .option("version", {
         abbr: "v",
@@ -37,7 +37,7 @@ var opts = nomnom
         help: "Print version and exit",
         callback: function() {
             return require("../package.json").version;
-        }
+        },
     })
     .parse();
 

--- a/bin/nearleyc.js
+++ b/bin/nearleyc.js
@@ -46,18 +46,15 @@ var version = require("../package.json").version;
 var input = opts.file ? fs.createReadStream(opts.file) : process.stdin;
 var output = opts.out ? fs.createWriteStream(opts.out) : process.stdout;
 
-var parserGrammar = nearley.Grammar.fromCompiled(require("../lib/nearley-language-bootstrapped.js"));
+var parserGrammar = nearley.Grammar.fromCompiled(
+    require("../lib/nearley-language-bootstrapped.js")
+);
 var parser = new nearley.Parser(parserGrammar);
 var generate = require("../lib/generate.js");
 var lint = require("../lib/lint.js");
 
-input
-    .pipe(new StreamWrapper(parser))
-    .on("finish", function() {
-        var c = Compile(
-            parser.results[0],
-            Object.assign({version: version}, opts)
-        );
-        if (!opts.quiet) lint(c, {"out": process.stderr, "version": version});
-        output.write(generate(c, opts.export));
-    });
+input.pipe(new StreamWrapper(parser)).on("finish", function() {
+    var c = Compile(parser.results[0], Object.assign({ version: version }, opts));
+    if (!opts.quiet) lint(c, { out: process.stderr, version: version });
+    output.write(generate(c, opts.export));
+});

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -19,7 +19,7 @@
             config: {}, // @config value
             macros: {},
             start: "",
-            version: opts.version || "unknown"
+            version: opts.version || "unknown",
         };
 
         for (var i = 0; i < structure.length; i++) {
@@ -63,8 +63,8 @@
                 }
             } else if (productionRule.macro) {
                 result.macros[productionRule.macro] = {
-                    "args": productionRule.args,
-                    "exprs": productionRule.exprs
+                    args: productionRule.args,
+                    exprs: productionRule.exprs,
                 };
             } else if (productionRule.config) {
                 // This isn't a rule, it's an @config.
@@ -162,16 +162,20 @@
 
         function buildStringToken(ruleName, token, env) {
             var newname = unique(ruleName + "$string");
-            produceRules(newname, [
-                {
-                    tokens: token.literal.split("").map(function charLiteral(d) {
-                        return {
-                            literal: d
-                        };
-                    }),
-                    postprocess: {builtin: "joiner"}
-                }
-            ], env);
+            produceRules(
+                newname,
+                [
+                    {
+                        tokens: token.literal.split("").map(function charLiteral(d) {
+                            return {
+                                literal: d,
+                            };
+                        }),
+                        postprocess: { builtin: "joiner" },
+                    },
+                ],
+                env
+            );
             return newname;
         }
 
@@ -207,13 +211,17 @@
                 }]
             });
             */
-            produceRules(name,
-                [{
-                    tokens: [token.ebnf],
-                }, {
-                    tokens: [name, token.ebnf],
-                    postprocess: {builtin: "arrpush"}
-                }],
+            produceRules(
+                name,
+                [
+                    {
+                        tokens: [token.ebnf],
+                    },
+                    {
+                        tokens: [name, token.ebnf],
+                        postprocess: { builtin: "arrpush" },
+                    },
+                ],
                 env
             );
             return name;
@@ -232,13 +240,17 @@
                 }]
             });
             */
-            produceRules(name,
-                [{
-                    tokens: [],
-                }, {
-                    tokens: [name, token.ebnf],
-                    postprocess: {builtin: "arrpush"}
-                }],
+            produceRules(
+                name,
+                [
+                    {
+                        tokens: [],
+                    },
+                    {
+                        tokens: [name, token.ebnf],
+                        postprocess: { builtin: "arrpush" },
+                    },
+                ],
                 env
             );
             return name;
@@ -258,14 +270,18 @@
                 }]
             });
             */
-            produceRules(name,
-                [{
-                    tokens: [token.ebnf],
-                    postprocess: {builtin: "id"}
-                }, {
-                    tokens: [],
-                    postprocess: {builtin: "nuller"}
-                }],
+            produceRules(
+                name,
+                [
+                    {
+                        tokens: [token.ebnf],
+                        postprocess: { builtin: "id" },
+                    },
+                    {
+                        tokens: [],
+                        postprocess: { builtin: "nuller" },
+                    },
+                ],
                 env
             );
             return name;

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,6 +1,6 @@
 (function(root, factory) {
-    if (typeof module === 'object' && module.exports) {
-        module.exports = factory(require('./nearley'));
+    if (typeof module === "object" && module.exports) {
+        module.exports = factory(require("./nearley"));
     } else {
         root.Compile = factory(root.nearley);
     }
@@ -18,8 +18,8 @@
             customTokens: [], // %tokens
             config: {}, // @config value
             macros: {},
-            start: '',
-            version: opts.version || 'unknown'
+            start: "",
+            version: opts.version || "unknown"
         };
 
         for (var i = 0; i < structure.length; i++) {
@@ -33,21 +33,21 @@
                 // Include file
                 var path;
                 if (!productionRule.builtin) {
-                    path = require('path').resolve(
-                        opts.file ? require('path').dirname(opts.file) : process.cwd(),
+                    path = require("path").resolve(
+                        opts.file ? require("path").dirname(opts.file) : process.cwd(),
                         productionRule.include
                     );
                 } else {
-                    path = require('path').resolve(
+                    path = require("path").resolve(
                         __dirname,
-                        '../builtin/',
+                        "../builtin/",
                         productionRule.include
                     );
                 }
                 if (opts.alreadycompiled.indexOf(path) === -1) {
                     opts.alreadycompiled.push(path);
-                    var f = require('fs').readFileSync(path).toString();
-                    var parserGrammar = nearley.Grammar.fromCompiled(require('./nearley-language-bootstrapped.js'));
+                    var f = require("fs").readFileSync(path).toString();
+                    var parserGrammar = nearley.Grammar.fromCompiled(require("./nearley-language-bootstrapped.js"));
                     var parser = new nearley.Parser(parserGrammar);
                     parser.feed(f);
                     var c = Compile(parser.results[0], {file: path, __proto__:opts});
@@ -63,8 +63,8 @@
                 }
             } else if (productionRule.macro) {
                 result.macros[productionRule.macro] = {
-                    'args': productionRule.args,
-                    'exprs': productionRule.exprs
+                    "args": productionRule.args,
+                    "exprs": productionRule.exprs
                 };
             } else if (productionRule.config) {
                 // This isn't a rule, it's an @config.
@@ -105,8 +105,8 @@
         }
 
         function buildToken(ruleName, token, env) {
-            if (typeof token === 'string') {
-                if (token === 'null') {
+            if (typeof token === "string") {
+                if (token === "null") {
                     return null;
                 }
                 return token;
@@ -298,7 +298,7 @@
         return unique;
         function unique(name) {
             var un = uns[name] = (uns[name] || 0) + 1;
-            return name + '$' + un;
+            return name + "$" + un;
         }
     }
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -4,8 +4,7 @@
     } else {
         root.Compile = factory(root.nearley);
     }
-}(this, function(nearley) {
-
+})(this, function(nearley) {
     function Compile(structure, opts) {
         var unique = uniquer();
         if (!opts.alreadycompiled) {
@@ -46,13 +45,17 @@
                 }
                 if (opts.alreadycompiled.indexOf(path) === -1) {
                     opts.alreadycompiled.push(path);
-                    var f = require("fs").readFileSync(path).toString();
-                    var parserGrammar = nearley.Grammar.fromCompiled(require("./nearley-language-bootstrapped.js"));
+                    var f = require("fs")
+                        .readFileSync(path)
+                        .toString();
+                    var parserGrammar = nearley.Grammar.fromCompiled(
+                        require("./nearley-language-bootstrapped.js")
+                    );
                     var parser = new nearley.Parser(parserGrammar);
                     parser.feed(f);
-                    var c = Compile(parser.results[0], {file: path, __proto__:opts});
+                    var c = Compile(parser.results[0], { file: path, __proto__: opts });
                     result.rules = result.rules.concat(c.rules);
-                    result.body  = result.body.concat(c.body);
+                    result.body = result.body.concat(c.body);
                     result.customTokens = result.customTokens.concat(c.customTokens);
                     Object.keys(c.config).forEach(function(k) {
                         result.config[k] = c.config[k];
@@ -68,7 +71,7 @@
                 };
             } else if (productionRule.config) {
                 // This isn't a rule, it's an @config.
-                result.config[productionRule.config] = productionRule.value
+                result.config[productionRule.config] = productionRule.value;
             } else {
                 produceRules(productionRule.name, productionRule.rules, {});
                 if (!result.start) {
@@ -97,11 +100,7 @@
                     tokens.push(token);
                 }
             }
-            return new nearley.Rule(
-                ruleName,
-                tokens,
-                rule.postprocess
-            );
+            return new nearley.Rule(ruleName, tokens, rule.postprocess);
         }
 
         function buildToken(ruleName, token, env) {
@@ -131,8 +130,15 @@
                     if (result.customTokens.indexOf(name) === -1) {
                         result.customTokens.push(name);
                     }
-                    var expr = result.config.lexer + ".has(" + JSON.stringify(name) + ") ? {type: " + JSON.stringify(name) + "} : " + name;
-                    return {token: "(" + expr + ")"};
+                    var expr =
+                        result.config.lexer +
+                        ".has(" +
+                        JSON.stringify(name) +
+                        ") ? {type: " +
+                        JSON.stringify(name) +
+                        "} : " +
+                        name;
+                    return { token: "(" + expr + ")" };
                 }
                 return token;
             }
@@ -291,13 +297,13 @@
             var name = unique(ruleName + "$macrocall");
             var macro = result.macros[token.macrocall];
             if (!macro) {
-                throw new Error("Unkown macro: "+token.macrocall);
+                throw new Error("Unkown macro: " + token.macrocall);
             }
             if (macro.args.length !== token.args.length) {
                 throw new Error("Argument count mismatch.");
             }
-            var newenv = {__proto__: env};
-            for (var i=0; i<macro.args.length; i++) {
+            var newenv = { __proto__: env };
+            for (var i = 0; i < macro.args.length; i++) {
                 var argrulename = unique(ruleName + "$macrocall");
                 newenv[macro.args[i]] = argrulename;
                 produceRules(argrulename, [token.args[i]], env);
@@ -313,11 +319,10 @@
         var uns = {};
         return unique;
         function unique(name) {
-            var un = uns[name] = (uns[name] || 0) + 1;
+            var un = (uns[name] = (uns[name] || 0) + 1);
             return name + "$" + un;
         }
     }
 
     return Compile;
-
-}));
+});

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,6 +1,6 @@
 (function(root, factory) {
-    if (typeof module === 'object' && module.exports) {
-        module.exports = factory(require('./nearley'));
+    if (typeof module === "object" && module.exports) {
+        module.exports = factory(require("./nearley"));
     } else {
         root.generate = factory(root.nearley);
     }
@@ -16,7 +16,7 @@
         var lines = func.toString().split(/\n/);
 
         if (lines.length === 1) {
-            return [lines[0].replace(/^\s+|\s+$/g, '')];
+            return [lines[0].replace(/^\s+|\s+$/g, "")];
         }
 
         var indent = null;
@@ -48,7 +48,7 @@
         if(Array.isArray(string)) {
           lines = string;
         } else {
-          lines = string.toString().split('\n');
+          lines = string.toString().split("\n");
         }
 
         options = options || {};
@@ -64,7 +64,7 @@
             } else {
                 return line;
             }
-        }).join('\n');
+        }).join("\n");
 
         return tabulated;
     }
@@ -80,16 +80,16 @@
     }
 
     function serializeRule(rule, builtinPostprocessors) {
-        var ret = '{';
+        var ret = "{";
         ret += '"name": ' + JSON.stringify(rule.name);
-        ret += ', "symbols": [' + rule.symbols.map(serializeSymbol).join(', ') + ']';
+        ret += ', "symbols": [' + rule.symbols.map(serializeSymbol).join(", ") + "]";
         if (rule.postprocess) {
             if(rule.postprocess.builtin) {
                 rule.postprocess = builtinPostprocessors[rule.postprocess.builtin];
             }
-            ret += ', "postprocess": ' + tabulateString(dedentFunc(rule.postprocess), '        ', {indentFirst: false});
+            ret += ', "postprocess": ' + tabulateString(dedentFunc(rule.postprocess), "        ", {indentFirst: false});
         }
-        ret += '}';
+        ret += "}";
         return ret;
     }
 
@@ -110,7 +110,7 @@
         output +=  "// http://github.com/Hardmath123/nearley\n";
         output += "(function () {\n";
         output += "function id(x) { return x[0]; }\n";
-        output += parser.body.join('\n');
+        output += parser.body.join("\n");
         output += "var grammar = {\n";
         output += "    Lexer: " + parser.config.lexer + ",\n";
         output += "    ParserRules: " +
@@ -140,13 +140,13 @@
         output +=  "# http://github.com/Hardmath123/nearley\n";
         output += "do ->\n";
         output += "  id = (d) -> d[0]\n";
-        output += tabulateString(dedentFunc(parser.body.join('\n')), '  ') + '\n';
+        output += tabulateString(dedentFunc(parser.body.join("\n")), "  ") + "\n";
         output += "  grammar = {\n";
         output += "    Lexer: " + parser.config.lexer + ",\n";
         output += "    ParserRules: " +
             tabulateString(
                     serializeRules(parser.rules, generate.coffeescript.builtinPostprocessors),
-                    '      ',
+                    "      ",
                     {indentFirst: false})
         + ",\n";
         output += "    ParserStart: " + JSON.stringify(parser.start) + "\n";
@@ -171,7 +171,7 @@
         output +=  "// http://github.com/Hardmath123/nearley\n";
         output += "function id(d: any[]): any { return d[0]; }\n";
         output += parser.customTokens.map(function (token) { return "declare var " + token + ": any;\n" }).join("")
-        output += parser.body.join('\n');
+        output += parser.body.join("\n");
         output += "\n";
         output += "export interface Token { value: any; [key: string]: any };\n";
         output += "\n";

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -1,5 +1,5 @@
 // Node-only
-var semver = require('semver');
+var semver = require("semver");
 
 var warn = function (opts, str) {
     opts.out.write("WARN"+"\t" + str + "\n");
@@ -22,8 +22,8 @@ function lintNames(grm, opts) {
 }
 
 function lintTSVersion(grm, opts) {
-    if (grm.config.preprocessor === 'typescript' &&
-        semver.gt(opts.version, '2.11.0'))
+    if (grm.config.preprocessor === "typescript" &&
+        semver.gt(opts.version, "2.11.0"))
         warn(opts, "The interface for the TypeScript preprocessor changed " +
                    "briefly in nearley 2.10 and 2.11. See " +
                    "https://github.com/Hardmath123/nearley/pull/287 if you " +

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -1,9 +1,9 @@
 // Node-only
 var semver = require("semver");
 
-var warn = function (opts, str) {
-    opts.out.write("WARN"+"\t" + str + "\n");
-}
+var warn = function(opts, str) {
+    opts.out.write("WARN" + "\t" + str + "\n");
+};
 
 function lintNames(grm, opts) {
     var all = [];
@@ -14,7 +14,7 @@ function lintNames(grm, opts) {
         rule.symbols.forEach(function(symbol) {
             if (!symbol.literal && !symbol.token && symbol.constructor !== RegExp) {
                 if (all.indexOf(symbol) === -1) {
-                    warn(opts,"Undefined symbol `" + symbol + "` used.");
+                    warn(opts, "Undefined symbol `" + symbol + "` used.");
                 }
             }
         });
@@ -22,12 +22,14 @@ function lintNames(grm, opts) {
 }
 
 function lintTSVersion(grm, opts) {
-    if (grm.config.preprocessor === "typescript" &&
-        semver.gt(opts.version, "2.11.0"))
-        warn(opts, "The interface for the TypeScript preprocessor changed " +
-                   "briefly in nearley 2.10 and 2.11. See " +
-                   "https://github.com/Hardmath123/nearley/pull/287 if you " +
-                   "encounter issues importing your grammar into TS.");
+    if (grm.config.preprocessor === "typescript" && semver.gt(opts.version, "2.11.0"))
+        warn(
+            opts,
+            "The interface for the TypeScript preprocessor changed " +
+                "briefly in nearley 2.10 and 2.11. See " +
+                "https://github.com/Hardmath123/nearley/pull/287 if you " +
+                "encounter issues importing your grammar into TS."
+        );
 }
 
 function lint(grm, opts) {

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -1,5 +1,5 @@
 (function(root, factory) {
-    if (typeof module === 'object' && module.exports) {
+    if (typeof module === "object" && module.exports) {
         module.exports = factory();
     } else {
         root.nearley = factory();
@@ -18,13 +18,13 @@
     Rule.prototype.toString = function(withCursorAt) {
         function stringifySymbolSequence (e) {
             return e.literal ? JSON.stringify(e.literal) :
-                   e.type ? '%' + e.type : e.toString();
+                   e.type ? "%" + e.type : e.toString();
         }
         var symbolSequence = (typeof withCursorAt === "undefined")
-                             ? this.symbols.map(stringifySymbolSequence).join(' ')
-                             : (   this.symbols.slice(0, withCursorAt).map(stringifySymbolSequence).join(' ')
+                             ? this.symbols.map(stringifySymbolSequence).join(" ")
+                             : (   this.symbols.slice(0, withCursorAt).map(stringifySymbolSequence).join(" ")
                                  + " ● "
-                                 + this.symbols.slice(withCursorAt).map(stringifySymbolSequence).join(' ')     );
+                                 + this.symbols.slice(withCursorAt).map(stringifySymbolSequence).join(" ")     );
         return this.name + " → " + symbolSequence;
     }
 
@@ -110,7 +110,7 @@
             } else {
                 // queue scannable states
                 var exp = state.rule.symbols[state.dot];
-                if (typeof exp !== 'string') {
+                if (typeof exp !== "string") {
                     this.scannable.push(state);
                     continue;
                 }
@@ -191,7 +191,7 @@
     StreamLexer.prototype.next = function() {
         if (this.index < this.buffer.length) {
             var ch = this.buffer[this.index++];
-            if (ch === '\n') {
+            if (ch === "\n") {
               this.line += 1;
               this.lastLineBreak = this.index;
             }
@@ -210,8 +210,8 @@
         // nb. this gets called after consuming the offending token,
         // so the culprit is index-1
         var buffer = this.buffer;
-        if (typeof buffer === 'string') {
-            var nextLineBreak = buffer.indexOf('\n', this.index);
+        if (typeof buffer === "string") {
+            var nextLineBreak = buffer.indexOf("\n", this.index);
             if (nextLineBreak === -1) nextLineBreak = buffer.length;
             var line = buffer.substring(this.lastLineBreak, nextLineBreak)
             var col = this.index - this.lastLineBreak;
@@ -358,7 +358,7 @@
     // nb. deprecated: use save/restore instead!
     Parser.prototype.rewind = function(index) {
         if (!this.options.keepHistory) {
-            throw new Error('set option `keepHistory` to enable rewinding')
+            throw new Error("set option `keepHistory` to enable rewinding")
         }
         // nb. recall column (table) indicies fall between token indicies.
         //        col 0   --   token 0   --   col 1

--- a/lib/nearley.js
+++ b/lib/nearley.js
@@ -4,30 +4,34 @@
     } else {
         root.nearley = factory();
     }
-}(this, function() {
-
+})(this, function() {
     function Rule(name, symbols, postprocess) {
         this.id = ++Rule.highestId;
         this.name = name;
-        this.symbols = symbols;        // a list of literal | regex class | nonterminal
+        this.symbols = symbols; // a list of literal | regex class | nonterminal
         this.postprocess = postprocess;
         return this;
     }
     Rule.highestId = 0;
 
     Rule.prototype.toString = function(withCursorAt) {
-        function stringifySymbolSequence (e) {
-            return e.literal ? JSON.stringify(e.literal) :
-                   e.type ? "%" + e.type : e.toString();
+        function stringifySymbolSequence(e) {
+            return e.literal ? JSON.stringify(e.literal) : e.type ? "%" + e.type : e.toString();
         }
-        var symbolSequence = (typeof withCursorAt === "undefined")
-                             ? this.symbols.map(stringifySymbolSequence).join(" ")
-                             : (   this.symbols.slice(0, withCursorAt).map(stringifySymbolSequence).join(" ")
-                                 + " ● "
-                                 + this.symbols.slice(withCursorAt).map(stringifySymbolSequence).join(" ")     );
+        var symbolSequence =
+            typeof withCursorAt === "undefined"
+                ? this.symbols.map(stringifySymbolSequence).join(" ")
+                : this.symbols
+                      .slice(0, withCursorAt)
+                      .map(stringifySymbolSequence)
+                      .join(" ") +
+                  " ● " +
+                  this.symbols
+                      .slice(withCursorAt)
+                      .map(stringifySymbolSequence)
+                      .join(" ");
         return this.name + " → " + symbolSequence;
-    }
-
+    };
 
     // a State is a rule at a position from a given starting point in the input stream (reference)
     function State(rule, dot, reference, wantedBy) {
@@ -70,7 +74,6 @@
         }
     };
 
-
     function Column(grammar, index) {
         this.grammar = grammar;
         this.index = index;
@@ -80,13 +83,13 @@
         this.completed = {}; // states that are nullable
     }
 
-
     Column.prototype.process = function(nextColumn) {
         var states = this.states;
         var wants = this.wants;
         var completed = this.completed;
 
-        for (var w = 0; w < states.length; w++) { // nb. we push() during iteration
+        for (var w = 0; w < states.length; w++) {
+            // nb. we push() during iteration
             var state = states[w];
 
             if (state.isComplete) {
@@ -94,7 +97,8 @@
                 if (state.data !== Parser.fail) {
                     // complete
                     var wantedBy = state.wantedBy;
-                    for (var i = wantedBy.length; i--; ) { // this line is hot
+                    for (var i = wantedBy.length; i--; ) {
+                        // this line is hot
                         var left = wantedBy[i];
                         this.complete(left, state);
                     }
@@ -106,7 +110,6 @@
                         (this.completed[exp] = this.completed[exp] || []).push(state);
                     }
                 }
-
             } else {
                 // queue scannable states
                 var exp = state.rule.symbols[state.dot];
@@ -132,7 +135,7 @@
                 }
             }
         }
-    }
+    };
 
     Column.prototype.predict = function(exp) {
         var rules = this.grammar.byName[exp] || [];
@@ -143,18 +146,17 @@
             var s = new State(r, 0, this.index, wantedBy);
             this.states.push(s);
         }
-    }
+    };
 
     Column.prototype.complete = function(left, right) {
         var copy = left.nextState(right);
         this.states.push(copy);
-    }
-
+    };
 
     function Grammar(rules, start) {
         this.rules = rules;
         this.start = start || this.rules[0].name;
-        var byName = this.byName = {};
+        var byName = (this.byName = {});
         this.rules.forEach(function(rule) {
             if (!byName.hasOwnProperty(rule.name)) {
                 byName[rule.name] = [];
@@ -167,18 +169,19 @@
     Grammar.fromCompiled = function(rules, start) {
         var lexer = rules.Lexer;
         if (rules.ParserStart) {
-          start = rules.ParserStart;
-          rules = rules.ParserRules;
+            start = rules.ParserStart;
+            rules = rules.ParserRules;
         }
-        var rules = rules.map(function (r) { return (new Rule(r.name, r.symbols, r.postprocess)); });
+        var rules = rules.map(function(r) {
+            return new Rule(r.name, r.symbols, r.postprocess);
+        });
         var g = new Grammar(rules, start);
         g.lexer = lexer; // nb. storing lexer on Grammar is iffy, but unavoidable
         return g;
-    }
-
+    };
 
     function StreamLexer() {
-      this.reset("");
+        this.reset("");
     }
 
     StreamLexer.prototype.reset = function(data, state) {
@@ -186,25 +189,25 @@
         this.index = 0;
         this.line = state ? state.line : 1;
         this.lastLineBreak = state ? -state.col : 0;
-    }
+    };
 
     StreamLexer.prototype.next = function() {
         if (this.index < this.buffer.length) {
             var ch = this.buffer[this.index++];
             if (ch === "\n") {
-              this.line += 1;
-              this.lastLineBreak = this.index;
+                this.line += 1;
+                this.lastLineBreak = this.index;
             }
-            return {value: ch};
+            return { value: ch };
         }
-    }
+    };
 
     StreamLexer.prototype.save = function() {
-      return {
-        line: this.line,
-        col: this.index - this.lastLineBreak,
-      }
-    }
+        return {
+            line: this.line,
+            col: this.index - this.lastLineBreak,
+        };
+    };
 
     StreamLexer.prototype.formatError = function(token, message) {
         // nb. this gets called after consuming the offending token,
@@ -213,17 +216,16 @@
         if (typeof buffer === "string") {
             var nextLineBreak = buffer.indexOf("\n", this.index);
             if (nextLineBreak === -1) nextLineBreak = buffer.length;
-            var line = buffer.substring(this.lastLineBreak, nextLineBreak)
+            var line = buffer.substring(this.lastLineBreak, nextLineBreak);
             var col = this.index - this.lastLineBreak;
             message += " at line " + this.line + " col " + col + ":\n\n";
-            message += "  " + line + "\n"
-            message += "  " + Array(col).join(" ") + "^"
+            message += "  " + line + "\n";
+            message += "  " + Array(col).join(" ") + "^";
             return message;
         } else {
             return message + " at index " + (this.index - 1);
         }
-    }
-
+    };
 
     function Parser(rules, start, options) {
         if (rules instanceof Grammar) {
@@ -237,9 +239,9 @@
         // Read options
         this.options = {
             keepHistory: false,
-            lexer: grammar.lexer || new StreamLexer,
+            lexer: grammar.lexer || new StreamLexer(),
         };
-        for (var key in (options || {})) {
+        for (var key in options || {}) {
             this.options[key] = options[key];
         }
 
@@ -249,7 +251,7 @@
 
         // Setup a table
         var column = new Column(grammar, 0);
-        var table = this.table = [column];
+        var table = (this.table = [column]);
 
         // I could be expecting anything.
         column.wants[grammar.start] = [];
@@ -267,7 +269,7 @@
         lexer.reset(chunk, this.lexerState);
 
         var token;
-        while (token = lexer.next()) {
+        while ((token = lexer.next())) {
             // We add new states to table[current+1]
             var column = this.table[this.current];
 
@@ -289,11 +291,18 @@
                 var expect = state.rule.symbols[state.dot];
                 // Try to consume the token
                 // either regex or literal
-                if (expect.test ? expect.test(value) :
-                    expect.type ? expect.type === token.type
-                                : expect.literal === literal) {
+                if (
+                    expect.test
+                        ? expect.test(value)
+                        : expect.type ? expect.type === token.type : expect.literal === literal
+                ) {
                     // Add it
-                    var next = state.nextState({data: value, token: token, isToken: true, reference: n - 1});
+                    var next = state.nextState({
+                        data: value,
+                        token: token,
+                        isToken: true,
+                        reference: n - 1,
+                    });
                     nextColumn.states.push(next);
                 }
             }
@@ -322,13 +331,13 @@
 
             // maybe save lexer state
             if (this.options.keepHistory) {
-              column.lexerState = lexer.save()
+                column.lexerState = lexer.save();
             }
 
             this.current++;
         }
         if (column) {
-          this.lexerState = lexer.save()
+            this.lexerState = lexer.save();
         }
 
         // Incrementally keep track of results
@@ -358,7 +367,7 @@
     // nb. deprecated: use save/restore instead!
     Parser.prototype.rewind = function(index) {
         if (!this.options.keepHistory) {
-            throw new Error("set option `keepHistory` to enable rewinding")
+            throw new Error("set option `keepHistory` to enable rewinding");
         }
         // nb. recall column (table) indicies fall between token indicies.
         //        col 0   --   token 0   --   col 1
@@ -369,16 +378,20 @@
         // Return the possible parsings
         var considerations = [];
         var start = this.grammar.start;
-        var column = this.table[this.table.length - 1]
-        column.states.forEach(function (t) {
-            if (t.rule.name === start
-                    && t.dot === t.rule.symbols.length
-                    && t.reference === 0
-                    && t.data !== Parser.fail) {
+        var column = this.table[this.table.length - 1];
+        column.states.forEach(function(t) {
+            if (
+                t.rule.name === start &&
+                t.dot === t.rule.symbols.length &&
+                t.reference === 0 &&
+                t.data !== Parser.fail
+            ) {
                 considerations.push(t);
             }
         });
-        return considerations.map(function(c) {return c.data; });
+        return considerations.map(function(c) {
+            return c.data;
+        });
     };
 
     return {
@@ -386,5 +399,4 @@
         Grammar: Grammar,
         Rule: Rule,
     };
-
-}));
+});

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,7 +1,7 @@
 // Node-only
 
-var Writable = require('stream').Writable;
-var util = require('util');
+var Writable = require("stream").Writable;
+var util = require("util");
 
 function StreamWrapper(parser) {
     Writable.call(this);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "benchmark": "benchr test/benchmark.js",
     "test": "mocha test/*.test.js",
     "doctoc": "doctoc --notitle README.md",
-    "profile": "bin/nearleyc.js test/grammars/parens.ne > test/grammars/parens.js && node test/profile.js"
+    "profile": "bin/nearleyc.js test/grammars/parens.ne > test/grammars/parens.js && node test/profile.js",
+    "fmt": "prettier --print-width=100 --tab-width=4 --trailing-comma es5 --write lib/{nearley,compile,generated,lint,stream}.js bin/*.js test/*.js"
   },
   "author": "Hardmath123",
   "contributors": "https://github.com/Hardmath123/nearley/graphs/contributors",
@@ -53,6 +54,7 @@
     "microtime": "^2.1.2",
     "mocha": "^2.5.3",
     "moo": "^0.3.2",
+    "prettier": "1.7.4",
     "typescript": "^2.3.4"
   }
 }

--- a/test/_shared.js
+++ b/test/_shared.js
@@ -1,11 +1,10 @@
+var path = require("path");
 
-var path = require('path');
+var nearley = require("../lib/nearley");
 
-var nearley = require('../lib/nearley');
-
-var Compile = require('../lib/compile');
-var parserGrammar = nearley.Grammar.fromCompiled(require('../lib/nearley-language-bootstrapped'));
-var generate = require('../lib/generate');
+var Compile = require("../lib/compile");
+var parserGrammar = nearley.Grammar.fromCompiled(require("../lib/nearley-language-bootstrapped"));
+var generate = require("../lib/generate");
 
 function parse(grammar, input) {
     var p = new nearley.Parser(grammar);
@@ -21,7 +20,7 @@ function nearleyc(source) {
     var c = Compile(results[0], {});
 
     // generate
-    return generate(c, 'grammar');
+    return generate(c, "grammar");
 }
 
 function compile(source) {
@@ -42,8 +41,8 @@ function requireFromString(source) {
 }
 */
 function requireFromString(source) {
-    var module = {exports: null};
-    eval(source)
+    var module = { exports: null };
+    eval(source);
     return module.exports;
 }
 
@@ -58,4 +57,3 @@ module.exports = {
     evalGrammar: evalGrammar,
     parse: parse,
 };
-

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,11 +1,11 @@
 
-const fs = require('fs');
+const fs = require("fs");
 
-const nearley = require('../lib/nearley');
-const {compile} = require('./_shared');
+const nearley = require("../lib/nearley");
+const {compile} = require("./_shared");
 
 function read(filename) {
-    return fs.readFileSync(filename, 'utf-8');
+    return fs.readFileSync(filename, "utf-8");
 }
 
 function makeParser(neFile) {
@@ -18,7 +18,7 @@ function makeParser(neFile) {
 
     return function parse(input) {
         if (grammar === null) {
-            throw 'grammar error';
+            throw "grammar error";
         }
         var p = new nearley.Parser(grammar);
         p.feed(input);
@@ -29,29 +29,29 @@ function makeParser(neFile) {
 
 // Define benchmarks
 
-suite('calculator', () => {
-  const exampleFile = 'ln (3 + 2*(8/e - sin(pi/5)))'
+suite("calculator", () => {
+  const exampleFile = "ln (3 + 2*(8/e - sin(pi/5)))"
 
-  const parse = makeParser('examples/calculator/arithmetic.ne')
-  benchmark('nearley', () => parse(exampleFile))
-
-})
-
-suite('json', () => {
-  const jsonFile = read('test/grammars/sample1k.json')
-
-  const parse = makeParser('examples/json.ne')
-  benchmark('nearley', () => parse(jsonFile))
-
-  //benchmark('native JSON 😛', () => JSON.parse(jsonFile))
+  const parse = makeParser("examples/calculator/arithmetic.ne")
+  benchmark("nearley", () => parse(exampleFile))
 
 })
 
-suite('tosh', () => {
-  const toshFile = 'set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))'
+suite("json", () => {
+  const jsonFile = read("test/grammars/sample1k.json")
 
-  const parse = makeParser('examples/tosh.ne')
-  benchmark('nearley', () => parse(toshFile))
+  const parse = makeParser("examples/json.ne")
+  benchmark("nearley", () => parse(jsonFile))
+
+  //benchmark("native JSON 😛", () => JSON.parse(jsonFile))
+
+})
+
+suite("tosh", () => {
+  const toshFile = "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))"
+
+  const parse = makeParser("examples/tosh.ne")
+  benchmark("nearley", () => parse(toshFile))
 
 })
 

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,8 +1,7 @@
-
 const fs = require("fs");
 
 const nearley = require("../lib/nearley");
-const {compile} = require("./_shared");
+const { compile } = require("./_shared");
 
 function read(filename) {
     return fs.readFileSync(filename, "utf-8");
@@ -23,35 +22,30 @@ function makeParser(neFile) {
         var p = new nearley.Parser(grammar);
         p.feed(input);
         return p.results;
-    }
+    };
 }
-
 
 // Define benchmarks
 
 suite("calculator", () => {
-  const exampleFile = "ln (3 + 2*(8/e - sin(pi/5)))"
+    const exampleFile = "ln (3 + 2*(8/e - sin(pi/5)))";
 
-  const parse = makeParser("examples/calculator/arithmetic.ne")
-  benchmark("nearley", () => parse(exampleFile))
-
-})
+    const parse = makeParser("examples/calculator/arithmetic.ne");
+    benchmark("nearley", () => parse(exampleFile));
+});
 
 suite("json", () => {
-  const jsonFile = read("test/grammars/sample1k.json")
+    const jsonFile = read("test/grammars/sample1k.json");
 
-  const parse = makeParser("examples/json.ne")
-  benchmark("nearley", () => parse(jsonFile))
+    const parse = makeParser("examples/json.ne");
+    benchmark("nearley", () => parse(jsonFile));
 
-  //benchmark("native JSON 😛", () => JSON.parse(jsonFile))
-
-})
+    //benchmark("native JSON 😛", () => JSON.parse(jsonFile))
+});
 
 suite("tosh", () => {
-  const toshFile = "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))"
+    const toshFile = "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))";
 
-  const parse = makeParser("examples/tosh.ne")
-  benchmark("nearley", () => parse(toshFile))
-
-})
-
+    const parse = makeParser("examples/tosh.ne");
+    benchmark("nearley", () => parse(toshFile));
+});

--- a/test/external.js
+++ b/test/external.js
@@ -1,18 +1,18 @@
 
-const fs = require('fs')
-const path = require('path')
-const child_process = require('child_process')
+const fs = require("fs")
+const path = require("path")
+const child_process = require("child_process")
 
-const root = 'test/'
+const root = "test/"
 
 function sh(cmd) {
-    return child_process.spawnSync(cmd, {shell: true, encoding: 'utf-8', stdio: 'pipe', cwd: root})
+    return child_process.spawnSync(cmd, {shell: true, encoding: "utf-8", stdio: "pipe", cwd: root})
 }
 
 var highestId = 0
 function externalNearleyc(input, ext, flags = []) {
-    const outPath = 'tmp.' + path.basename(input) + (++highestId)
-    const {stderr, stdout} = sh(`../bin/nearleyc.js ${flags.join(' ')} ${input} -o ${outPath}${ext}`);
+    const outPath = "tmp." + path.basename(input) + (++highestId)
+    const {stderr, stdout} = sh(`../bin/nearleyc.js ${flags.join(" ")} ${input} -o ${outPath}${ext}`);
     return {outPath, stderr, stdout}
 }
 

--- a/test/external.js
+++ b/test/external.js
@@ -1,28 +1,33 @@
+const fs = require("fs");
+const path = require("path");
+const child_process = require("child_process");
 
-const fs = require("fs")
-const path = require("path")
-const child_process = require("child_process")
-
-const root = "test/"
+const root = "test/";
 
 function sh(cmd) {
-    return child_process.spawnSync(cmd, {shell: true, encoding: "utf-8", stdio: "pipe", cwd: root})
+    return child_process.spawnSync(cmd, {
+        shell: true,
+        encoding: "utf-8",
+        stdio: "pipe",
+        cwd: root,
+    });
 }
 
-var highestId = 0
+var highestId = 0;
 function externalNearleyc(input, ext, flags = []) {
-    const outPath = "tmp." + path.basename(input) + (++highestId)
-    const {stderr, stdout} = sh(`../bin/nearleyc.js ${flags.join(" ")} ${input} -o ${outPath}${ext}`);
-    return {outPath, stderr, stdout}
+    const outPath = "tmp." + path.basename(input) + ++highestId;
+    const { stderr, stdout } = sh(
+        `../bin/nearleyc.js ${flags.join(" ")} ${input} -o ${outPath}${ext}`
+    );
+    return { outPath, stderr, stdout };
 }
 
 function cleanup() {
     for (let name of fs.readdirSync(root)) {
         if (/^tmp\./.test(name)) {
-            fs.unlinkSync(path.join(root, name))
+            fs.unlinkSync(path.join(root, name));
         }
     }
 }
 
-module.exports = {sh, externalNearleyc, cleanup}
-
+module.exports = { sh, externalNearleyc, cleanup };

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -5,48 +5,43 @@ const lint = require("../lib/lint");
 describe("Linter", function() {
     var mockGrammar, mockOpts, writeSpy;
 
-    beforeEach(function () {
+    beforeEach(function() {
         mockGrammar = {
             rules: [],
-            config: {}
+            config: {},
         };
         mockOpts = {
             out: {
-                write() {}
-            }
+                write() {},
+            },
         };
         writeSpy = expect.spyOn(mockOpts.out, "write");
-    })
+    });
 
-    it("runs without warnings on empty rules", function () {
+    it("runs without warnings on empty rules", function() {
         lint(mockGrammar, mockOpts);
         expect(writeSpy).toNotHaveBeenCalled();
     });
 
-    it("warns about undefined symbol", function () {
-        mockGrammar.rules = [
-            {name: "a", symbols: ["non-existent"]}
-        ];
+    it("warns about undefined symbol", function() {
+        mockGrammar.rules = [{ name: "a", symbols: ["non-existent"] }];
         lint(mockGrammar, mockOpts);
         expect(writeSpy).toHaveBeenCalled();
     });
 
-    it("doesn't warn about defined symbol", function () {
-        mockGrammar.rules =  [
-            {name: "a", symbols: []},
-            {name: "b", symbols: ["a"]}
-        ];
+    it("doesn't warn about defined symbol", function() {
+        mockGrammar.rules = [{ name: "a", symbols: [] }, { name: "b", symbols: ["a"] }];
         lint(mockGrammar, mockOpts);
         expect(writeSpy).toNotHaveBeenCalled();
     });
 
-    it("doesn't warn about duplicate symbol", function () {
-        mockGrammar.rules =  [
-            {name: "a", symbols: []},
-            {name: "a", symbols: []},
-            {name: "b", symbols: ["a"]}
+    it("doesn't warn about duplicate symbol", function() {
+        mockGrammar.rules = [
+            { name: "a", symbols: [] },
+            { name: "a", symbols: [] },
+            { name: "b", symbols: ["a"] },
         ];
         lint(mockGrammar, mockOpts);
         expect(writeSpy).toNotHaveBeenCalled();
     });
-})
+});

--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -1,13 +1,13 @@
 
-const fs = require('fs');
-const expect = require('expect');
+const fs = require("fs");
+const expect = require("expect");
 
-const nearley = require('../lib/nearley');
-const {compile, evalGrammar, parse, nearleyc} = require('./_shared');
-const {sh, externalNearleyc, cleanup} = require('./external');
+const nearley = require("../lib/nearley");
+const {compile, evalGrammar, parse, nearleyc} = require("./_shared");
+const {sh, externalNearleyc, cleanup} = require("./external");
 
 function read(filename) {
-    return fs.readFileSync(filename, 'utf-8');
+    return fs.readFileSync(filename, "utf-8");
 }
 
 function prettyPrint(grammar) {
@@ -17,54 +17,54 @@ function prettyPrint(grammar) {
 describe("bin/nearleyc", function() {
     after(cleanup)
 
-    it('builds for ES5', function() {
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/parens.ne", '.js');
+    it("builds for ES5", function() {
+        const {outPath, stdout, stderr} = externalNearleyc("grammars/parens.ne", ".js");
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
     });
 
-    it('builds for CoffeeScript', function() {
+    it("builds for CoffeeScript", function() {
         const {outPath, stdout, stderr} = externalNearleyc("grammars/coffeescript-test.ne", ".coffee");
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         sh(`coffee -c ${outPath}.coffee`);
         const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
-        expect(parse(grammar, "ABCDEFZ12309")).toEqual([ [ 'ABCDEFZ', '12309' ] ]);
+        expect(parse(grammar, "ABCDEFZ12309")).toEqual([ [ "ABCDEFZ", "12309" ] ]);
     });
 
-    it('builds for TypeScript', function() {
+    it("builds for TypeScript", function() {
         this.timeout(10000); // It takes a while to run tsc!
         const {outPath, stdout, stderr} = externalNearleyc("grammars/typescript-test.ne", ".ts");
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         sh(`tsc ${outPath}.ts`);
         const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
-        expect(parse(grammar, "<123>")).toEqual([ [ '<', '123', '>' ] ]);
+        expect(parse(grammar, "<123>")).toEqual([ [ "<", "123", ">" ] ]);
     });
 
-    it('builds modules in folders', function() {
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/folder-test.ne", '.js');
+    it("builds modules in folders", function() {
+        const {outPath, stdout, stderr} = externalNearleyc("grammars/folder-test.ne", ".js");
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
     });
 
-    it('builds modules with multiple includes of the same file', function() {
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/multi-include-test.ne", '.js');
+    it("builds modules with multiple includes of the same file", function() {
+        const {outPath, stdout, stderr} = externalNearleyc("grammars/multi-include-test.ne", ".js");
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
     });
 
     it("warns about undefined symbol", function () {
-        const {stdout, stderr} = externalNearleyc("grammars/warning-undefined-test.ne", '.js');
+        const {stdout, stderr} = externalNearleyc("grammars/warning-undefined-test.ne", ".js");
         expect(stderr).toNotBe("");
         expect(stdout).toBe("");
     });
 
     it("doesn't warn when used with the --quiet option", function () {
-        const {stdout, stderr} = externalNearleyc("grammars/warning-undefined-test.ne", '.js', ['--quiet']);
+        const {stdout, stderr} = externalNearleyc("grammars/warning-undefined-test.ne", ".js", ["--quiet"]);
         expect(stderr).toBe("");
         expect(stdout).toBe("");
     });
@@ -72,14 +72,14 @@ describe("bin/nearleyc", function() {
 
 })
 
-describe('nearleyc: example grammars', function() {
+describe("nearleyc: example grammars", function() {
 
-    it('calculator example', function() {
+    it("calculator example", function() {
         const arith = compile(read("examples/calculator/arithmetic.ne"));
         expect(parse(arith, "ln (3 + 2*(8/e - sin(pi/5)))")).toEqual([ Math.log(3 + 2*(8/Math.exp(1) - Math.sin(Math.PI/5))) ]);
     });
 
-    it('csscolor example', function() {
+    it("csscolor example", function() {
         const cssc = compile(read("examples/csscolor.ne"));
         expect(parse(cssc, "#FF00FF")).toEqual([{r: 0xff, g: 0x00, b: 0xff}]);
         expect(parse(cssc, "#8A7")).toEqual([{r: 0x88, g: 0xaa, b: 0x77}]);
@@ -88,56 +88,56 @@ describe('nearleyc: example grammars', function() {
         expect(function() { parse(cssc, "#badcolor"); }).toThrow()
     });
 
-    it('exponential whitespace bug', function() {
-        compile(read('test/grammars/indentation.ne'));
+    it("exponential whitespace bug", function() {
+        compile(read("test/grammars/indentation.ne"));
     });
 
-    it('percent bug', function() {
-        compile(read('test/grammars/percent.ne'));
+    it("percent bug", function() {
+        compile(read("test/grammars/percent.ne"));
     });
 
-    it('json', function() {
+    it("json", function() {
         const grammar = compile(read("examples/json.ne"));
         expect(prettyPrint(grammar)).toEqual([
-            'json$subexpression$1 → object',
-            'json$subexpression$1 → array',
-            'json → _ json$subexpression$1 _',
+            "json$subexpression$1 → object",
+            "json$subexpression$1 → array",
+            "json → _ json$subexpression$1 _",
             'object → "{" _ "}"',
-            'object$ebnf$1 → ',
+            "object$ebnf$1 → ",
             'object$ebnf$1$subexpression$1 → _ "," _ pair',
-            'object$ebnf$1 → object$ebnf$1 object$ebnf$1$subexpression$1',
+            "object$ebnf$1 → object$ebnf$1 object$ebnf$1$subexpression$1",
             'object → "{" _ pair object$ebnf$1 _ "}"',
             'array → "[" _ "]"',
-            'array$ebnf$1 → ',
+            "array$ebnf$1 → ",
             'array$ebnf$1$subexpression$1 → _ "," _ value',
-            'array$ebnf$1 → array$ebnf$1 array$ebnf$1$subexpression$1',
+            "array$ebnf$1 → array$ebnf$1 array$ebnf$1$subexpression$1",
             'array → "[" _ value array$ebnf$1 _ "]"',
-            'value → object',
-            'value → array',
-            'value → number',
-            'value → string',
+            "value → object",
+            "value → array",
+            "value → number",
+            "value → string",
             'value → "true"',
             'value → "false"',
             'value → "null"',
-            'number → %number',
-            'string → %string',
+            "number → %number",
+            "string → %string",
             'pair → key _ ":" _ value',
-            'key → string',
-            '_ → ',
-            '_ → %space',
+            "key → string",
+            "_ → ",
+            "_ → %space",
         ])
     });
 
-    it('classic crontab', function() {
+    it("classic crontab", function() {
         // Try compiling the grammar
         const classicCrontab = compile(read("examples/classic_crontab.ne"));
         // Try parsing crontab file using the newly generated parser
-        const crontabTest = read('test/grammars/classic_crontab.test');
-        const crontabResults = read('test/grammars/classic_crontab.results');
+        const crontabTest = read("test/grammars/classic_crontab.test");
+        const crontabResults = read("test/grammars/classic_crontab.results");
         expect(parse(classicCrontab, crontabTest)).toEqual([JSON.parse(crontabResults)]);
     });
 
-    it('case-insensitive strings', function() {
+    it("case-insensitive strings", function() {
         const caseinsensitive = compile(read("test/grammars/caseinsensitive.ne"));
         const passCases = [
             "Les rêves des amoureux sont comme le bon vin!",
@@ -154,19 +154,19 @@ describe('nearleyc: example grammars', function() {
 
 });
 
-describe('nearleyc: builtins', () => {
+describe("nearleyc: builtins", () => {
 
-    it('generate includes id', () => {
+    it("generate includes id", () => {
         const source = nearleyc(`
         X -> "hat" {% id %}
         `)
-        expect(source.indexOf('function id(')).toNotBe(-1)
+        expect(source.indexOf("function id(")).toNotBe(-1)
         const g = evalGrammar(source)
         expect(parse(g, "hat")).toEqual(["hat"])
     })
 
     // TODO fix docs?
-    it.skip('nuller', () => {
+    it.skip("nuller", () => {
         //@builtin "postprocessors.ne"
         const source = nearleyc(`
         ws -> " " {% nuller %}
@@ -176,10 +176,10 @@ describe('nearleyc: builtins', () => {
     })
 })
 
-describe('nearleyc: macros', () => {
+describe("nearleyc: macros", () => {
 
-    it('seems to work', () => {
-        // Matches "'Hello?' 'Hello?' 'Hello?'"
+    it("seems to work", () => {
+        // Matches ""Hello?" "Hello?" "Hello?""
         const grammar = compile(`
             matchThree[X] -> $X " " $X " " $X
             inQuotes[X] -> "'" $X "'"
@@ -188,23 +188,23 @@ describe('nearleyc: macros', () => {
 
         expect(prettyPrint(grammar)).toEqual([
             'main$macrocall$2$macrocall$2$string$1 → "H" "e" "l" "l" "o" "?"',
-            'main$macrocall$2$macrocall$2 → main$macrocall$2$macrocall$2$string$1',
+            "main$macrocall$2$macrocall$2 → main$macrocall$2$macrocall$2$string$1",
             'main$macrocall$2$macrocall$1 → "\'" main$macrocall$2$macrocall$2 "\'"',
-            'main$macrocall$2 → main$macrocall$2$macrocall$1',
+            "main$macrocall$2 → main$macrocall$2$macrocall$1",
             'main$macrocall$1 → main$macrocall$2 " " main$macrocall$2 " " main$macrocall$2',
-            'main → main$macrocall$1',
+            "main → main$macrocall$1",
         ]);
     });
 
-    it('must be defined before use', () => {
+    it("must be defined before use", () => {
         expect(() => compile(`
             main -> matchThree[inQuotes["Hello?"]]
             matchThree[X] -> $X " " $X " " $X
-            inQuotes[X] -> "'" $X "'"
+            inQuotes[X] -> """ $X """
         `)).toThrow();
     });
 
-    it('compiles a simple macro from external file', function() {
+    it("compiles a simple macro from external file", function() {
         const grammar = compile(read("test/grammars/macro-test.ne"));
         const passCases = [
             "a",

--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -1,91 +1,99 @@
-
 const fs = require("fs");
 const expect = require("expect");
 
 const nearley = require("../lib/nearley");
-const {compile, evalGrammar, parse, nearleyc} = require("./_shared");
-const {sh, externalNearleyc, cleanup} = require("./external");
+const { compile, evalGrammar, parse, nearleyc } = require("./_shared");
+const { sh, externalNearleyc, cleanup } = require("./external");
 
 function read(filename) {
     return fs.readFileSync(filename, "utf-8");
 }
 
 function prettyPrint(grammar) {
-  return grammar.rules.map(g => g.toString())
+    return grammar.rules.map(g => g.toString());
 }
 
 describe("bin/nearleyc", function() {
-    after(cleanup)
+    after(cleanup);
 
     it("builds for ES5", function() {
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/parens.ne", ".js");
+        const { outPath, stdout, stderr } = externalNearleyc("grammars/parens.ne", ".js");
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
     });
 
     it("builds for CoffeeScript", function() {
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/coffeescript-test.ne", ".coffee");
+        const { outPath, stdout, stderr } = externalNearleyc(
+            "grammars/coffeescript-test.ne",
+            ".coffee"
+        );
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         sh(`coffee -c ${outPath}.coffee`);
         const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
-        expect(parse(grammar, "ABCDEFZ12309")).toEqual([ [ "ABCDEFZ", "12309" ] ]);
+        expect(parse(grammar, "ABCDEFZ12309")).toEqual([["ABCDEFZ", "12309"]]);
     });
 
     it("builds for TypeScript", function() {
         this.timeout(10000); // It takes a while to run tsc!
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/typescript-test.ne", ".ts");
+        const { outPath, stdout, stderr } = externalNearleyc("grammars/typescript-test.ne", ".ts");
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         sh(`tsc ${outPath}.ts`);
         const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
-        expect(parse(grammar, "<123>")).toEqual([ [ "<", "123", ">" ] ]);
+        expect(parse(grammar, "<123>")).toEqual([["<", "123", ">"]]);
     });
 
     it("builds modules in folders", function() {
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/folder-test.ne", ".js");
+        const { outPath, stdout, stderr } = externalNearleyc("grammars/folder-test.ne", ".js");
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
     });
 
     it("builds modules with multiple includes of the same file", function() {
-        const {outPath, stdout, stderr} = externalNearleyc("grammars/multi-include-test.ne", ".js");
+        const { outPath, stdout, stderr } = externalNearleyc(
+            "grammars/multi-include-test.ne",
+            ".js"
+        );
         expect(stderr).toBe("");
         expect(stdout).toBe("");
         const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
     });
 
-    it("warns about undefined symbol", function () {
-        const {stdout, stderr} = externalNearleyc("grammars/warning-undefined-test.ne", ".js");
+    it("warns about undefined symbol", function() {
+        const { stdout, stderr } = externalNearleyc("grammars/warning-undefined-test.ne", ".js");
         expect(stderr).toNotBe("");
         expect(stdout).toBe("");
     });
 
-    it("doesn't warn when used with the --quiet option", function () {
-        const {stdout, stderr} = externalNearleyc("grammars/warning-undefined-test.ne", ".js", ["--quiet"]);
+    it("doesn't warn when used with the --quiet option", function() {
+        const { stdout, stderr } = externalNearleyc("grammars/warning-undefined-test.ne", ".js", [
+            "--quiet",
+        ]);
         expect(stderr).toBe("");
         expect(stdout).toBe("");
     });
-
-
-})
+});
 
 describe("nearleyc: example grammars", function() {
-
     it("calculator example", function() {
         const arith = compile(read("examples/calculator/arithmetic.ne"));
-        expect(parse(arith, "ln (3 + 2*(8/e - sin(pi/5)))")).toEqual([ Math.log(3 + 2*(8/Math.exp(1) - Math.sin(Math.PI/5))) ]);
+        expect(parse(arith, "ln (3 + 2*(8/e - sin(pi/5)))")).toEqual([
+            Math.log(3 + 2 * (8 / Math.exp(1) - Math.sin(Math.PI / 5))),
+        ]);
     });
 
     it("csscolor example", function() {
         const cssc = compile(read("examples/csscolor.ne"));
-        expect(parse(cssc, "#FF00FF")).toEqual([{r: 0xff, g: 0x00, b: 0xff}]);
-        expect(parse(cssc, "#8A7")).toEqual([{r: 0x88, g: 0xaa, b: 0x77}]);
-        expect(parse(cssc, "rgb(99,66,33)")).toEqual([{r: 99, g: 66, b: 33}]);
-        expect(parse(cssc, "hsl(99,66,33)")).toEqual([{h: 99, s: 66, l: 33}]);
-        expect(function() { parse(cssc, "#badcolor"); }).toThrow()
+        expect(parse(cssc, "#FF00FF")).toEqual([{ r: 0xff, g: 0x00, b: 0xff }]);
+        expect(parse(cssc, "#8A7")).toEqual([{ r: 0x88, g: 0xaa, b: 0x77 }]);
+        expect(parse(cssc, "rgb(99,66,33)")).toEqual([{ r: 99, g: 66, b: 33 }]);
+        expect(parse(cssc, "hsl(99,66,33)")).toEqual([{ h: 99, s: 66, l: 33 }]);
+        expect(function() {
+            parse(cssc, "#badcolor");
+        }).toThrow();
     });
 
     it("exponential whitespace bug", function() {
@@ -125,7 +133,7 @@ describe("nearleyc: example grammars", function() {
             "key → string",
             "_ → ",
             "_ → %space",
-        ])
+        ]);
     });
 
     it("classic crontab", function() {
@@ -143,41 +151,38 @@ describe("nearleyc: example grammars", function() {
             "Les rêves des amoureux sont comme le bon vin!",
             "LES RÊVES DES AMOUREUX SONT COMME LE BON VIN!",
             "leS RêVeS DeS AmOuReUx sOnT CoMmE Le bOn vIn!",
-            "LEs rÊvEs dEs aMoUrEuX SoNt cOmMe lE BoN ViN!"
+            "LEs rÊvEs dEs aMoUrEuX SoNt cOmMe lE BoN ViN!",
         ];
         passCases.forEach(function(c) {
             const p = parse(caseinsensitive, c);
-            expect(p.length).toBe(1)
+            expect(p.length).toBe(1);
             expect(p[0].toUpperCase()).toBe(passCases[1]);
         });
     });
-
 });
 
 describe("nearleyc: builtins", () => {
-
     it("generate includes id", () => {
         const source = nearleyc(`
         X -> "hat" {% id %}
-        `)
-        expect(source.indexOf("function id(")).toNotBe(-1)
-        const g = evalGrammar(source)
-        expect(parse(g, "hat")).toEqual(["hat"])
-    })
+        `);
+        expect(source.indexOf("function id(")).toNotBe(-1);
+        const g = evalGrammar(source);
+        expect(parse(g, "hat")).toEqual(["hat"]);
+    });
 
     // TODO fix docs?
     it.skip("nuller", () => {
         //@builtin "postprocessors.ne"
         const source = nearleyc(`
         ws -> " " {% nuller %}
-        `)
-        const g = evalGrammar(source)
-        expect(parse(g, " ")).toEqual([null])
-    })
-})
+        `);
+        const g = evalGrammar(source);
+        expect(parse(g, " ")).toEqual([null]);
+    });
+});
 
 describe("nearleyc: macros", () => {
-
     it("seems to work", () => {
         // Matches ""Hello?" "Hello?" "Hello?""
         const grammar = compile(`
@@ -197,21 +202,18 @@ describe("nearleyc: macros", () => {
     });
 
     it("must be defined before use", () => {
-        expect(() => compile(`
+        expect(() =>
+            compile(`
             main -> matchThree[inQuotes["Hello?"]]
             matchThree[X] -> $X " " $X " " $X
             inQuotes[X] -> """ $X """
-        `)).toThrow();
+        `)
+        ).toThrow();
     });
 
     it("compiles a simple macro from external file", function() {
         const grammar = compile(read("test/grammars/macro-test.ne"));
-        const passCases = [
-            "a",
-            "b",
-            "a/b",
-            "b/a",
-        ];
+        const passCases = ["a", "b", "a/b", "b/a"];
         passCases.forEach(function(c) {
             const p = parse(grammar, c);
             expect(p.length).toBe(1);
@@ -219,5 +221,4 @@ describe("nearleyc: macros", () => {
         });
         expect(() => parse(grammar, "ab")).toThrow();
     });
-
-})
+});

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,36 +1,28 @@
-
 const fs = require("fs");
 const expect = require("expect");
 
 const nearley = require("../lib/nearley");
-const {compile, parse} = require("./_shared");
+const { compile, parse } = require("./_shared");
 
 function read(filename) {
     return fs.readFileSync(filename, "utf-8");
 }
 
-
 describe("Parser: API", function() {
-
     let testGrammar = compile(`
     y -> x:+
     x -> [a-z0-9] | "\\n"
-    `)
+    `);
 
     it("shows line number in errors", function() {
-      expect(() => parse(testGrammar, "abc\n12!")).toThrow(
-        "invalid syntax at line 2 col 3:\n" +
-        "\n" +
-        "  12!\n" +
-        "    ^"
-      )
-    })
+        expect(() => parse(testGrammar, "abc\n12!")).toThrow(
+            "invalid syntax at line 2 col 3:\n" + "\n" + "  12!\n" + "    ^"
+        );
+    });
 
     it("shows token index in errors", function() {
-      expect(() => parse(testGrammar, ["1", "2", "!"])).toThrow(
-        "invalid syntax at index 2"
-      )
-    })
+        expect(() => parse(testGrammar, ["1", "2", "!"])).toThrow("invalid syntax at index 2");
+    });
 
     var tosh = compile(read("examples/tosh.ne"));
 
@@ -39,11 +31,11 @@ describe("Parser: API", function() {
         let second = " for 2 secs";
         let p = new nearley.Parser(tosh, { keepHistory: true });
         p.feed(first);
-        expect(p.current).toBe(11)
-        expect(p.table.length).toBe(12)
+        expect(p.current).toBe(11);
+        expect(p.table.length).toBe(12);
         var col = p.save();
-        expect(col.index).toBe(11)
-        expect(col.lexerState.col).toBe(first.length)
+        expect(col.index).toBe(11);
+        expect(col.lexerState.col).toBe(first.length);
     });
 
     it("can rewind", function() {
@@ -51,63 +43,60 @@ describe("Parser: API", function() {
         let second = " for 2 secs";
         let p = new nearley.Parser(tosh, { keepHistory: true });
         p.feed(first);
-        expect(p.current).toBe(11)
-        expect(p.table.length).toBe(12)
+        expect(p.current).toBe(11);
+        expect(p.table.length).toBe(12);
 
         p.feed(second);
 
         p.rewind(first.length);
 
-        expect(p.current).toBe(11)
-        expect(p.table.length).toBe(12)
+        expect(p.current).toBe(11);
+        expect(p.table.length).toBe(12);
 
         expect(p.results).toEqual([["say:", "hello"]]);
     });
 
     it("won't rewind without `keepHistory` option", function() {
         let p = new nearley.Parser(tosh, {});
-        expect(() => p.rewind()).toThrow()
-    })
+        expect(() => p.rewind()).toThrow();
+    });
 
     it("restores line numbers", function() {
-      let p = new nearley.Parser(testGrammar);
-      p.feed("abc\n")
-      expect(p.save().lexerState.line).toBe(2)
-      p.feed("123\n")
-      var col = p.save();
-      expect(col.lexerState.line).toBe(3)
-      p.feed("q")
-      p.restore(col);
-      expect(p.lexer.line).toBe(3)
-      p.feed("z")
+        let p = new nearley.Parser(testGrammar);
+        p.feed("abc\n");
+        expect(p.save().lexerState.line).toBe(2);
+        p.feed("123\n");
+        var col = p.save();
+        expect(col.lexerState.line).toBe(3);
+        p.feed("q");
+        p.restore(col);
+        expect(p.lexer.line).toBe(3);
+        p.feed("z");
     });
 
     it("restores column number", function() {
-      let p = new nearley.Parser(testGrammar);
-      p.feed("foo\nbar")
-      var col = p.save();
-      expect(col.lexerState.line).toBe(2)
-      expect(col.lexerState.col).toBe(3)
-      p.feed("123");
-      expect(p.lexerState.col).toBe(6)
+        let p = new nearley.Parser(testGrammar);
+        p.feed("foo\nbar");
+        var col = p.save();
+        expect(col.lexerState.line).toBe(2);
+        expect(col.lexerState.col).toBe(3);
+        p.feed("123");
+        expect(p.lexerState.col).toBe(6);
 
-      p.restore(col);
-      expect(p.lexerState.line).toBe(2)
-      expect(p.lexerState.col).toBe(3)
-      p.feed("456")
-      expect(p.lexerState.col).toBe(6)
+        p.restore(col);
+        expect(p.lexerState.line).toBe(2);
+        expect(p.lexerState.col).toBe(3);
+        p.feed("456");
+        expect(p.lexerState.col).toBe(6);
     });
 
     // TODO: moo save/restore
-
 });
 
 describe("Parser: examples", () => {
-
     it("nullable whitespace bug", function() {
         var wsb = compile(read("test/grammars/whitespace.ne"));
-        expect(parse(wsb, "(x)")).toEqual(
-            [ [ [ [ "(", null, [ [ [ [ "x" ] ] ] ], null, ")" ] ] ] ]);
+        expect(parse(wsb, "(x)")).toEqual([[[["(", null, [[[["x"]]]], null, ")"]]]]);
     });
 
     const parentheses = compile(read("examples/parentheses.ne"));
@@ -116,22 +105,19 @@ describe("Parser: examples", () => {
             "()",
             "[(){}<>]",
             "[(((<>)()({})())(()())(())[])]",
-            "<<[([])]>([(<>[]{}{}<>())[{}[][]{}{}[]<>[]{}<>{}<>[]<>{}()][[][][]()()()]({})<[]>{(){}()<>}(<>[])]())({})>"
+            "<<[([])]>([(<>[]{}{}<>())[{}[][]{}{}[]<>[]{}<>{}<>[]<>{}()][[][][]()()()]({})<[]>{(){}()<>}(<>[])]())({})>",
         ];
 
         for (let i in passCases) {
             expect(parse(parentheses, passCases[i])).toEqual([true]);
         }
 
-        var failCases = [
-            " ",
-            "[}",
-            "[(){}><]",
-            "(((())))(()))"
-        ];
+        var failCases = [" ", "[}", "[(){}><]", "(((())))(()))"];
 
         for (let i in failCases) {
-            expect(function() { parse(parentheses, failCases[i]); }).toThrow()
+            expect(function() {
+                parse(parentheses, failCases[i]);
+            }).toThrow();
         }
 
         // These are invalid inputs but the parser will not complain
@@ -141,23 +127,53 @@ describe("Parser: examples", () => {
 
     it("tokens", function() {
         var tokc = compile(read("examples/token.ne"));
-        expect(parse(tokc, [123, 456, " ", 789])).toEqual([ [123, [ [ 456, " ", 789 ] ]] ]);
+        expect(parse(tokc, [123, 456, " ", 789])).toEqual([[123, [[456, " ", 789]]]]);
     });
 
     const json = compile(read("examples/json.ne"));
     it("json", () => {
-        const test1 = '{ "a" : true, "b" : "䕧⡱a\\\\\\"b\\u4567\\u2871䕧⡱\\t\\r\\f\\b\\n", "c" : null, "d" : [null, true, false, null] }\n'
-        expect(parse(json, test1)).toEqual([JSON.parse(test1)])
+        const test1 =
+            '{ "a" : true, "b" : "䕧⡱a\\\\\\"b\\u4567\\u2871䕧⡱\\t\\r\\f\\b\\n", "c" : null, "d" : [null, true, false, null] }\n';
+        expect(parse(json, test1)).toEqual([JSON.parse(test1)]);
 
-        const test2 = '{ "a" : true, "b" : "䕧⡱a\\\\\\"b\\u4567\\u2871䕧⡱\\t\\r\\f\\b\\n\\u0010\\u001f\\u005b\\u005c\\u005d", "c" : null, "d" : [null, true, false, -0.2345E+10] }\n'
-        expect(parse(json, test2)).toEqual([JSON.parse(test2)])
+        const test2 =
+            '{ "a" : true, "b" : "䕧⡱a\\\\\\"b\\u4567\\u2871䕧⡱\\t\\r\\f\\b\\n\\u0010\\u001f\\u005b\\u005c\\u005d", "c" : null, "d" : [null, true, false, -0.2345E+10] }\n';
+        expect(parse(json, test2)).toEqual([JSON.parse(test2)]);
     });
 
     it("tosh", () => {
         var tosh = compile(read("examples/tosh.ne"));
-        expect(parse(tosh, "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))"))
-            .toEqual([["setVar:to:","foo",["*",["*",2,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]],["-",1,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]]]]]);
-    })
-
-})
-
+        expect(
+            parse(
+                tosh,
+                "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))"
+            )
+        ).toEqual([
+            [
+                "setVar:to:",
+                "foo",
+                [
+                    "*",
+                    [
+                        "*",
+                        2,
+                        [
+                            "computeFunction:of:",
+                            "e ^",
+                            ["+", ["*", ["readVariable", "foo"], -0.05], 0.5],
+                        ],
+                    ],
+                    [
+                        "-",
+                        1,
+                        [
+                            "computeFunction:of:",
+                            "e ^",
+                            ["+", ["*", ["readVariable", "foo"], -0.05], 0.5],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    });
+});

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,40 +1,40 @@
 
-const fs = require('fs');
-const expect = require('expect');
+const fs = require("fs");
+const expect = require("expect");
 
-const nearley = require('../lib/nearley');
-const {compile, parse} = require('./_shared');
+const nearley = require("../lib/nearley");
+const {compile, parse} = require("./_shared");
 
 function read(filename) {
-    return fs.readFileSync(filename, 'utf-8');
+    return fs.readFileSync(filename, "utf-8");
 }
 
 
-describe('Parser: API', function() {
+describe("Parser: API", function() {
 
     let testGrammar = compile(`
     y -> x:+
     x -> [a-z0-9] | "\\n"
     `)
 
-    it('shows line number in errors', function() {
-      expect(() => parse(testGrammar, 'abc\n12!')).toThrow(
-        'invalid syntax at line 2 col 3:\n' +
-        '\n' +
-        '  12!\n' +
-        '    ^'
+    it("shows line number in errors", function() {
+      expect(() => parse(testGrammar, "abc\n12!")).toThrow(
+        "invalid syntax at line 2 col 3:\n" +
+        "\n" +
+        "  12!\n" +
+        "    ^"
       )
     })
 
-    it('shows token index in errors', function() {
-      expect(() => parse(testGrammar, ['1', '2', '!'])).toThrow(
-        'invalid syntax at index 2'
+    it("shows token index in errors", function() {
+      expect(() => parse(testGrammar, ["1", "2", "!"])).toThrow(
+        "invalid syntax at index 2"
       )
     })
 
     var tosh = compile(read("examples/tosh.ne"));
 
-    it('can save state', function() {
+    it("can save state", function() {
         let first = "say 'hello'";
         let second = " for 2 secs";
         let p = new nearley.Parser(tosh, { keepHistory: true });
@@ -46,7 +46,7 @@ describe('Parser: API', function() {
         expect(col.lexerState.col).toBe(first.length)
     });
 
-    it('can rewind', function() {
+    it("can rewind", function() {
         let first = "say 'hello'";
         let second = " for 2 secs";
         let p = new nearley.Parser(tosh, { keepHistory: true });
@@ -61,7 +61,7 @@ describe('Parser: API', function() {
         expect(p.current).toBe(11)
         expect(p.table.length).toBe(12)
 
-        expect(p.results).toEqual([['say:', 'hello']]);
+        expect(p.results).toEqual([["say:", "hello"]]);
     });
 
     it("won't rewind without `keepHistory` option", function() {
@@ -69,32 +69,32 @@ describe('Parser: API', function() {
         expect(() => p.rewind()).toThrow()
     })
 
-    it('restores line numbers', function() {
+    it("restores line numbers", function() {
       let p = new nearley.Parser(testGrammar);
-      p.feed('abc\n')
+      p.feed("abc\n")
       expect(p.save().lexerState.line).toBe(2)
-      p.feed('123\n')
+      p.feed("123\n")
       var col = p.save();
       expect(col.lexerState.line).toBe(3)
-      p.feed('q')
+      p.feed("q")
       p.restore(col);
       expect(p.lexer.line).toBe(3)
-      p.feed('z')
+      p.feed("z")
     });
 
-    it('restores column number', function() {
+    it("restores column number", function() {
       let p = new nearley.Parser(testGrammar);
-      p.feed('foo\nbar')
+      p.feed("foo\nbar")
       var col = p.save();
       expect(col.lexerState.line).toBe(2)
       expect(col.lexerState.col).toBe(3)
-      p.feed('123');
+      p.feed("123");
       expect(p.lexerState.col).toBe(6)
 
       p.restore(col);
       expect(p.lexerState.line).toBe(2)
       expect(p.lexerState.col).toBe(3)
-      p.feed('456')
+      p.feed("456")
       expect(p.lexerState.col).toBe(6)
     });
 
@@ -102,21 +102,21 @@ describe('Parser: API', function() {
 
 });
 
-describe('Parser: examples', () => {
+describe("Parser: examples", () => {
 
-    it('nullable whitespace bug', function() {
+    it("nullable whitespace bug", function() {
         var wsb = compile(read("test/grammars/whitespace.ne"));
         expect(parse(wsb, "(x)")).toEqual(
-            [ [ [ [ '(', null, [ [ [ [ 'x' ] ] ] ], null, ')' ] ] ] ]);
+            [ [ [ [ "(", null, [ [ [ [ "x" ] ] ] ], null, ")" ] ] ] ]);
     });
 
     const parentheses = compile(read("examples/parentheses.ne"));
-    it('parentheses', () => {
+    it("parentheses", () => {
         var passCases = [
-            '()',
-            '[(){}<>]',
-            '[(((<>)()({})())(()())(())[])]',
-            '<<[([])]>([(<>[]{}{}<>())[{}[][]{}{}[]<>[]{}<>{}<>[]<>{}()][[][][]()()()]({})<[]>{(){}()<>}(<>[])]())({})>'
+            "()",
+            "[(){}<>]",
+            "[(((<>)()({})())(()())(())[])]",
+            "<<[([])]>([(<>[]{}{}<>())[{}[][]{}{}[]<>[]{}<>{}<>[]<>{}()][[][][]()()()]({})<[]>{(){}()<>}(<>[])]())({})>"
         ];
 
         for (let i in passCases) {
@@ -124,10 +124,10 @@ describe('Parser: examples', () => {
         }
 
         var failCases = [
-            ' ',
-            '[}',
-            '[(){}><]',
-            '(((())))(()))'
+            " ",
+            "[}",
+            "[(){}><]",
+            "(((())))(()))"
         ];
 
         for (let i in failCases) {
@@ -135,17 +135,17 @@ describe('Parser: examples', () => {
         }
 
         // These are invalid inputs but the parser will not complain
-        expect(parse(parentheses, '')).toEqual([]);
-        expect(parse(parentheses, '((((())))(())()')).toEqual([]);
+        expect(parse(parentheses, "")).toEqual([]);
+        expect(parse(parentheses, "((((())))(())()")).toEqual([]);
     });
 
-    it('tokens', function() {
+    it("tokens", function() {
         var tokc = compile(read("examples/token.ne"));
         expect(parse(tokc, [123, 456, " ", 789])).toEqual([ [123, [ [ 456, " ", 789 ] ]] ]);
     });
 
     const json = compile(read("examples/json.ne"));
-    it('json', () => {
+    it("json", () => {
         const test1 = '{ "a" : true, "b" : "䕧⡱a\\\\\\"b\\u4567\\u2871䕧⡱\\t\\r\\f\\b\\n", "c" : null, "d" : [null, true, false, null] }\n'
         expect(parse(json, test1)).toEqual([JSON.parse(test1)])
 
@@ -153,7 +153,7 @@ describe('Parser: examples', () => {
         expect(parse(json, test2)).toEqual([JSON.parse(test2)])
     });
 
-    it('tosh', () => {
+    it("tosh", () => {
         var tosh = compile(read("examples/tosh.ne"));
         expect(parse(tosh, "set foo to 2 * e^ of ( foo * -0.05 + 0.5) * (1 - e ^ of (foo * -0.05 + 0.5))"))
             .toEqual([["setVar:to:","foo",["*",["*",2,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]],["-",1,["computeFunction:of:","e ^",["+",["*",["readVariable","foo"],-0.05],0.5]]]]]]);

--- a/test/profile.js
+++ b/test/profile.js
@@ -1,5 +1,5 @@
-var nearley = require('../lib/nearley.js');
-var parserGrammar = require('./grammars/parens.js');
+var nearley = require("../lib/nearley.js");
+var parserGrammar = require("./grammars/parens.js");
 function nspace(n) {
 	var out = "";
 	for (var i=0; i<n; i++) {

--- a/test/profile.js
+++ b/test/profile.js
@@ -1,51 +1,50 @@
 var nearley = require("../lib/nearley.js");
 var parserGrammar = require("./grammars/parens.js");
 function nspace(n) {
-	var out = "";
-	for (var i=0; i<n; i++) {
-		out += " ";
-	}
-	return out;
+    var out = "";
+    for (var i = 0; i < n; i++) {
+        out += " ";
+    }
+    return out;
 }
 
 function profile(n, type) {
-	var test = "";
-	for (var i=0; i<n; i++) {
-		test += "(";
-	}
-	test += "acowcowcowcowcowcowcowcowcow";
-	for (var i=0; i<n; i++) {
-		test += ")";
-	}
-	var starttime = process.hrtime();
-	var startmemory = process.memoryUsage().heapUsed;
-	var p = new nearley.Parser(parserGrammar.ParserRules, parserGrammar.ParserStart).feed(test);
-	console.assert(p.results[0]);
-	switch (type) {
-	case "TIME":
-		var tdiff = process.hrtime(starttime)[1];
-		console.log(
-			nspace(Math.round(tdiff/1e9  *80))+"*" // how much of one second
-		);
-		break;
-	case "MEMO":
-		var mdiff = process.memoryUsage().heapUsed - startmemory;
-		console.log(
-			nspace(Math.round(mdiff/1e8  *80)) + "+"
-		);
-	}
+    var test = "";
+    for (var i = 0; i < n; i++) {
+        test += "(";
+    }
+    test += "acowcowcowcowcowcowcowcowcow";
+    for (var i = 0; i < n; i++) {
+        test += ")";
+    }
+    var starttime = process.hrtime();
+    var startmemory = process.memoryUsage().heapUsed;
+    var p = new nearley.Parser(parserGrammar.ParserRules, parserGrammar.ParserStart).feed(test);
+    console.assert(p.results[0]);
+    switch (type) {
+        case "TIME":
+            var tdiff = process.hrtime(starttime)[1];
+            console.log(
+                nspace(Math.round(tdiff / 1e9 * 80)) + "*" // how much of one second
+            );
+            break;
+        case "MEMO":
+            var mdiff = process.memoryUsage().heapUsed - startmemory;
+            console.log(nspace(Math.round(mdiff / 1e8 * 80)) + "+");
+    }
 }
 
 console.log("Nearley test.");
 console.log("=============");
-console.log("Tests operate on the grammar p -> \"(\" p \")\" | [a-z]");
+console.log('Tests operate on the grammar p -> "(" p ")" | [a-z]');
 console.log("An input of size n is 2n+1 characters long, and of the form (((...a...))).");
 console.log();
 
-
 console.log("Running time tests.");
 console.log("-------------------");
-console.log("Each star corresponds to the time taken to parse an input of that size with a recursive grammar.");
+console.log(
+    "Each star corresponds to the time taken to parse an input of that size with a recursive grammar."
+);
 console.log();
 console.log("SCALE");
 console.log(nspace(20) + "0.25s");
@@ -53,18 +52,21 @@ console.log(nspace(40) + "0.50s");
 console.log(nspace(60) + "0.75s");
 console.log(nspace(80) + "1.00s");
 
-for (var i=0; i<5e4; i+=2e3) {
-	if (i%1e4 === 0) {
-		console.log(i);
-	}
-	profile(i, "TIME");
+for (var i = 0; i < 5e4; i += 2e3) {
+    if (i % 1e4 === 0) {
+        console.log(i);
+    }
+    profile(i, "TIME");
 }
-
 
 console.log("Running memory tests.");
 console.log("-------------------");
-console.log("Each star corresponds to the memory taken to parse an input of that size with a recursive grammar.");
-console.log("Occasional outliers may be caused by gc runs. Nearley profiling doesn't explicitly call the gc before each run.");
+console.log(
+    "Each star corresponds to the memory taken to parse an input of that size with a recursive grammar."
+);
+console.log(
+    "Occasional outliers may be caused by gc runs. Nearley profiling doesn't explicitly call the gc before each run."
+);
 console.log();
 console.log("SCALE");
 console.log(nspace(20) + "025MB");
@@ -72,9 +74,9 @@ console.log(nspace(40) + "050MB");
 console.log(nspace(60) + "075MB");
 console.log(nspace(80) + "100MB");
 
-for (var i=0; i<5e4; i+=2e3) {
-	if (i%1e4 === 0) {
-		console.log(i);
-	}
-	profile(i, "MEMO");
+for (var i = 0; i < 5e4; i += 2e3) {
+    if (i % 1e4 === 0) {
+        console.log(i);
+    }
+    profile(i, "MEMO");
 }


### PR DESCRIPTION
Previously #313.

* The script is called `fmt`, after `go fmt`.
* I'm still not thrilled about this; it would be nice to tidy things up and make things more consistent, but automated linting tools can never make code as pretty as a human would.
* I split the major changes (re-indenting, double-quoted strings, reformatting) into separate commits, to make the changes easier to review (and make sure we don't break anything!).