### PR TITLE
Bypass TS6133 error by allowing function declarations that are unused

### DIFF
--- a/builtin/postprocessors.ne
+++ b/builtin/postprocessors.ne
@@ -3,6 +3,8 @@
 # Postprocessor generator that lets you select the nth element of the list.
 # `id` is equivalent to nth(0).
 @{%
+// Bypasses TS6133. Allow declared but unused functions.
+// @ts-ignore
 function nth(n) {
     return function(d) {
         return d[n];
@@ -12,6 +14,8 @@ function nth(n) {
 
 # Postprocessor generator that lets you generate an object dynamically.
 @{%
+// Bypasses TS6133. Allow declared but unused functions.
+// @ts-ignore
 function $(o) {
     return function(d) {
         var ret = {};

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -181,6 +181,8 @@
     generate.ts = generate.typescript = function (parser, exportName) {
         var output = "// Generated automatically by nearley, version " + parser.version + "\n";
         output +=  "// http://github.com/Hardmath123/nearley\n";
+        output +=  "// Bypasses TS6133. Allow declared but unused functions.\n";
+        output +=  "// @ts-ignore\n";
         output += "function id(d: any[]): any { return d[0]; }\n";
         output += parser.customTokens.map(function (token) { return "declare var " + token + ": any;\n" }).join("")
         output += parser.body.join('\n');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2615,9 +2615,9 @@
       }
     },
     "typescript": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
-      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
       "dev": true
     },
     "underscore": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "microtime": "^2.1.2",
     "mocha": "^2.5.3",
     "moo": "^0.3.2",
-    "typescript": "^2.3.4"
+    "typescript": "^2.6.1"
   }
 }


### PR DESCRIPTION
With the [release](https://github.com/Microsoft/TypeScript/releases/tag/v2.6.1) of TypeScript 2.6.1, we now have the option to [suppress errors in .ts files using '// @ts-ignore' comments](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#suppress-errors-in-ts-files-using--ts-ignore-comments).

Fixes #322 