### PR TITLE
Added tokens from lexer as terminals in railroad diagram

### DIFF
--- a/bin/nearley-railroad.js
+++ b/bin/nearley-railroad.js
@@ -93,6 +93,8 @@ function railroad(grm) {
                 return new rr.NonTerminal(tok);
             } else if (tok.constructor === RegExp) {
                 return new rr.Terminal(tok.toString());
+            } else if (tok.token) {
+                return new rr.Terminal(tok.token);
             } else {
                 return new rr.Comment("[Unimplemented]");
             }


### PR DESCRIPTION
If you use e.g. moo as a lexer, terminals are shown as "[Unimplemented]" in the railroad diagram. This adds them as terminals with the token name